### PR TITLE
Adds a description for the base go-blueprint command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,16 +14,9 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "go-blueprint",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+	Short: "A program to spin up a quick Go project using a popular framework",
+	Long: `Go Blueprint is a CLI tool that allows users to spin up a Go project with the corresponding structure seamlessly. 
+It also gives the option to integrate with one of the more popular Go frameworks!`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
Changes the description of the program from the default that comes with Cobra to one that matches the README.md descriptions.