### PR TITLE
adding invalid name error

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"log"
 	"os"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	tpl "github.com/melkeydev/go-blueprint/cmd/template"
@@ -93,7 +94,13 @@ func (p *Project) CreateMainFile() error {
 		}
 	}
 
-	// First lets create a new director with the project name
+	// First Check if project name has any invalid characters
+	containsSpace := strings.Contains(p.ProjectName, " ")
+	if containsSpace {
+		log.Println("Invlaid Project Name")
+	}
+
+	// Then lets create a new directory with the project name
 	if _, err := os.Stat(fmt.Sprintf("%s/%s", p.AbsolutePath, p.ProjectName)); os.IsNotExist(err) {
 		err := os.MkdirAll(fmt.Sprintf("%s/%s", p.AbsolutePath, p.ProjectName), 0751)
 		if err != nil {


### PR DESCRIPTION
when the project name is invalid for go mod init instead of the error printing "Could not init go mod in new project" instead it prints "invalid project name" so it tells the user that he needs to change the name, while not replacing the first error's function which it states that go is not being able to init because of something preventing the directory to create e.g admin rights and lack of storage space.
