### PR TITLE
A github action to create a release on git tag

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.1'
+
+      - name: Install dependencies
+        run: go mod tidy
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Build
+        run: |
+          env GOOS=linux GOARCH=amd64 go build -o bin/go-blueprint-x86 main.go
+          env GOOS=linux GOARCH=arm64 go build -o bin/go-blueprint-arm main.go
+
+      - name: Create release
+        id: release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ./bin/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added a workflow that builds binaries for arm and x86 and creates a release with them on a git tag with the pattern `v*.*.*`

You can check out [my fork](https://github.com/MitchellBerend/go-blueprint) for an example with `v69.420.0`