### PR TITLE
ci: linting on generated code

### DIFF
--- a/.github/workflows/generate-linter.yml
+++ b/.github/workflows/generate-linter.yml
@@ -1,0 +1,26 @@
+name: Linting Generated Blueprints
+
+on:
+    pull_request: {}
+
+jobs:
+    framework_matrix:
+        strategy:
+            matrix:
+                framework: [chi, gin, fiber, gorilla/mux, httprouter, standard-library, echo]
+                goVersion: [1.20]
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup Go
+              uses: actions/setup-go@v3
+              with:
+                go-version: 1.20
+            - name: build templates
+              run: go run main.go create -n ${{ matrix.framework }} -f ${{ matrix.framework}}
+            
+            - name: golangci-lint
+              working-directory: ${{ matrix.framework }}
+              run: |
+                go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+                golangci-lint run --timeout 5m

--- a/.github/workflows/generate-linter.yml
+++ b/.github/workflows/generate-linter.yml
@@ -8,19 +8,19 @@ jobs:
         strategy:
             matrix:
                 framework: [chi, gin, fiber, gorilla/mux, httprouter, standard-library, echo]
-                goVersion: [1.20]
+                goVersion: ["1.20"]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Setup Go
-              uses: actions/setup-go@v3
+              uses: actions/setup-go@v4
               with:
-                go-version: 1.20
+                go-version: ${{ matrix.goVersion }}
             - name: build templates
               run: go run main.go create -n ${{ matrix.framework }} -f ${{ matrix.framework}}
-            
             - name: golangci-lint
-              working-directory: ${{ matrix.framework }}
-              run: |
-                go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
-                golangci-lint run --timeout 5m
+              uses: golangci/golangci-lint-action@v3
+              with:
+                version: v1.55.2     
+                working-directory: ${{ matrix.framework }}
+                args: --timeout=5m

--- a/.github/workflows/generate-linter.yml
+++ b/.github/workflows/generate-linter.yml
@@ -2,6 +2,7 @@ name: Linting Generated Blueprints
 
 on:
     pull_request: {}
+    workflow_dispatch: {}
 
 jobs:
     framework_matrix:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,7 @@ name: Linting
 
 on:
   pull_request:
+  
 
 jobs:
   lint:


### PR DESCRIPTION
This PR will run `golangci-lint` against all the generated repositories.

Things to improve:
- ~~Don't install `golangci-lint` for each item in the matrix~~ 
- Uses `golangci-lint` predefined action
- Add a `.golangci.yaml` file with desired linter configuration

resolve #39