### PR TITLE
Fixing broken linting pipeline

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,8 +16,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-        go mod tidy
-        go mod download
+          go mod tidy
+          go mod download
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0


### PR DESCRIPTION
A broken workflow was added in #28, this fixes the indentation errors.