### PR TITLE
Non-interactive environment breaks matrix workflows

### DIFF
--- a/.github/workflows/generate-linter.yml
+++ b/.github/workflows/generate-linter.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           go-version: ${{ matrix.goVersion }}
       - name: build templates
-        run: go run main.go create -n ${{ matrix.framework }} -f ${{ matrix.framework}}
+        run: |
+          script -q /dev/null -c "go run main.go create -n ${{ matrix.framework }} -f ${{ matrix.framework}}" /dev/null
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/generate-linter.yml
+++ b/.github/workflows/generate-linter.yml
@@ -26,10 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.goVersion }}
       - name: build templates
         run: |
           script -q /dev/null -c "go run main.go create -n ${{ matrix.framework }} -f ${{ matrix.framework}}" /dev/null


### PR DESCRIPTION
# Error

Matrix breaks with `error: open /dev/tty: no such device or address`

Seems like under the hood Matrix runs a non-interactive shell. Because the CLI is being run to generate the artifacts to be linted it will error out.

# Fix

Using`script` binary to fake a tty so that it doesn't complain.