### PR TITLE
feat: add spinner v4

### DIFF
--- a/.github/workflows/generate-linter.yml
+++ b/.github/workflows/generate-linter.yml
@@ -40,3 +40,5 @@ jobs:
           version: v1.55.2
           working-directory: ${{ matrix.framework }}
           args: --timeout=5m
+      - name: remove templates
+        run: rm -rf ${{ matrix.framework }}

--- a/.github/workflows/generate-linter.yml
+++ b/.github/workflows/generate-linter.yml
@@ -28,10 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.goVersion }}
       - name: build templates
         run: go run main.go create -n ${{ matrix.framework }} -f ${{ matrix.framework}} -d ${{ matrix.driver }}
       - name: golangci-lint

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -16,9 +16,6 @@ import (
 	"github.com/melkeydev/go-blueprint/cmd/ui/textinput"
 	"github.com/melkeydev/go-blueprint/cmd/utils"
 	"github.com/spf13/cobra"
-	"log"
-	"os"
-	"strings"
 )
 
 const logo = `

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -183,6 +183,8 @@ var createCmd = &cobra.Command{
 			nonInteractiveCommand := utils.NonInteractiveCommand(cmd.Use, cmd.Flags())
 			fmt.Println(tipMsgStyle.Render("Tip: Repeat the equivalent Blueprint with the following non-interactive command:"))
 			fmt.Println(tipMsgStyle.Italic(false).Render(fmt.Sprintf("• %s\n", nonInteractiveCommand)))
+			project.Exit = true
+			project.ExitCLI(tprogram)
 		}
 	},
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/melkeydev/go-blueprint/cmd/program"
 	"github.com/melkeydev/go-blueprint/cmd/steps"
 	"github.com/melkeydev/go-blueprint/cmd/ui/multiInput"
+	"github.com/melkeydev/go-blueprint/cmd/ui/spinner"
 	"github.com/melkeydev/go-blueprint/cmd/ui/textinput"
 	"github.com/melkeydev/go-blueprint/cmd/utils"
 	"github.com/spf13/cobra"
@@ -154,12 +155,25 @@ var createCmd = &cobra.Command{
 			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 		}
 		project.AbsolutePath = currentWorkingDir
+		spinStatus := make(chan bool)
 
-		// This calls the templates
-		err = project.CreateMainFile()
-		if err != nil {
-			log.Printf("Problem creating files for project. %v", err)
-			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
+		go func() {
+			err = project.CreateMainFile()
+			if err != nil {
+				log.Printf("Problem creating files for project. %v", err)
+				cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
+			}
+		}()
+		go func() {
+			tprogram = tea.NewProgram(spinner.InitialModelNew())
+			if _, err := tprogram.Run(); err != nil {
+				cobra.CheckErr(err)
+			}
+		}()
+
+		if <-spinStatus {
+			close(spinStatus)
+			project.ExitCLI(tprogram)
 		}
 
 		fmt.Println(endingMsgStyle.Render("\nNext steps cd into the newly created project with:"))

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -184,7 +184,11 @@ var createCmd = &cobra.Command{
 			fmt.Println(tipMsgStyle.Render("Tip: Repeat the equivalent Blueprint with the following non-interactive command:"))
 			fmt.Println(tipMsgStyle.Italic(false).Render(fmt.Sprintf("• %s\n", nonInteractiveCommand)))
 		}
-		tprogram.ReleaseTerminal()
+		err = tprogram.ReleaseTerminal()
+		if err != nil {
+			log.Printf("Could not release terminal: %v", err)
+			cobra.CheckErr(err)
+		}
 	},
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -183,9 +183,8 @@ var createCmd = &cobra.Command{
 			nonInteractiveCommand := utils.NonInteractiveCommand(cmd.Use, cmd.Flags())
 			fmt.Println(tipMsgStyle.Render("Tip: Repeat the equivalent Blueprint with the following non-interactive command:"))
 			fmt.Println(tipMsgStyle.Italic(false).Render(fmt.Sprintf("• %s\n", nonInteractiveCommand)))
-			project.Exit = true
-			project.ExitCLI(tprogram)
 		}
+		tprogram.ReleaseTerminal()
 	},
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -67,7 +67,6 @@ var createCmd = &cobra.Command{
 		flagName := cmd.Flag("name").Value.String()
 		if flagName != "" && doesDirectoryExistAndIsNotEmpty(flagName) {
 			err = fmt.Errorf("directory '%s' already exists and is not empty. Please choose a different name", flagName)
-			err = fmt.Errorf("directory '%s' already exists and is not empty. Please choose a different name", flagName)
 			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 		}
 		flagFramework := cmd.Flag("framework").Value.String()
@@ -76,7 +75,6 @@ var createCmd = &cobra.Command{
 		if flagFramework != "" {
 			isValid := isValidProjectType(flagFramework, allowedProjectTypes)
 			if !isValid {
-				err = fmt.Errorf("project type '%s' is not valid. Valid types are: %s", flagFramework, strings.Join(allowedProjectTypes, ", "))
 				err = fmt.Errorf("project type '%s' is not valid. Valid types are: %s", flagFramework, strings.Join(allowedProjectTypes, ", "))
 				cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 			}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -158,14 +158,6 @@ var createCmd = &cobra.Command{
 		spinStatus := make(chan struct{})
 
 		go func() {
-			err = project.CreateMainFile()
-			close(spinStatus)
-			if err != nil {
-				log.Printf("Problem creating files for project. %v", err)
-				cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
-			}
-		}()
-		go func() {
 			if isInteractive {
 				tprogram = tea.NewProgram(spinner.InitialModelNew())
 					if _, err := tprogram.Run(); err != nil {
@@ -173,6 +165,12 @@ var createCmd = &cobra.Command{
 					}
 			}
 		}()
+		err = project.CreateMainFile()
+		close(spinStatus)
+		if err != nil {
+			log.Printf("Problem creating files for project. %v", err)
+			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
+		}
 
 		<-spinStatus
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -155,7 +155,6 @@ var createCmd = &cobra.Command{
 			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 		}
 		project.AbsolutePath = currentWorkingDir
-		spinStatus := make(chan struct{})
 
 		go func() {
 			if isInteractive {
@@ -163,16 +162,14 @@ var createCmd = &cobra.Command{
 					if _, err := tprogram.Run(); err != nil {
 						cobra.CheckErr(err)
 					}
+
 			}
 		}()
 		err = project.CreateMainFile()
-		close(spinStatus)
 		if err != nil {
 			log.Printf("Problem creating files for project. %v", err)
 			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 		}
-
-		<-spinStatus
 
 		fmt.Println(endingMsgStyle.Render("\nNext steps cd into the newly created project with:"))
 		fmt.Println(endingMsgStyle.Render(fmt.Sprintf("• cd %s\n", project.ProjectName)))

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -151,7 +151,6 @@ func (p *Project) createDBDriverMap() {
 	}
 }
 
-
 // CreateMainFile creates the project folders and files,
 // and writes to them depending on the selected options
 func (p *Project) CreateMainFile() error {

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -151,6 +151,7 @@ func (p *Project) createDBDriverMap() {
 	}
 }
 
+
 // CreateMainFile creates the project folders and files,
 // and writes to them depending on the selected options
 func (p *Project) CreateMainFile() error {

--- a/cmd/ui/spinner/spinner.go
+++ b/cmd/ui/spinner/spinner.go
@@ -1,0 +1,62 @@
+package spinner
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type errMsg error
+
+type model struct {
+	spinner  spinner.Model
+	quitting bool
+	err      error
+}
+
+func InitialModelNew() model {
+	s := spinner.New()
+	s.Spinner = spinner.Line
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	return model{spinner: s}
+}
+
+func (m model) Init() tea.Cmd {
+	return m.spinner.Tick
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc", "ctrl+c":
+			m.quitting = true
+			return m, tea.Quit
+		default:
+			return m, nil
+		}
+
+	case errMsg:
+		m.err = msg
+		return m, nil
+
+	default:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	}
+}
+
+func (m model) View() string {
+
+	if m.err != nil {
+		return m.err.Error()
+	}
+	str := fmt.Sprintf("\n\n   %s Preparing...\n\n", m.spinner.View())
+	if m.quitting {
+		return str + "\n"
+	}
+	return str
+}

--- a/cmd/ui/textinput/textinput.go
+++ b/cmd/ui/textinput/textinput.go
@@ -17,6 +17,7 @@ var (
 	titleStyle = lipgloss.NewStyle().Background(lipgloss.Color("#01FAC6")).Foreground(lipgloss.Color("#030303")).Bold(true).Padding(0, 1, 0)
 	errorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8700")).Bold(true).Padding(0, 0, 0)
 )
+
 type (
 	errMsg error
 )


### PR DESCRIPTION
The previous implementation for the spinner was entering interactive mode all the time, this caused GHA that would run `go-blueprint` at any point  to fail. 
This affected the generate projects linting as of now, but any action that would use the `go-blueprint create` would have had the same issue.