### PR TITLE
Project name input is not being sanitized

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Linting
+name: continuous integration
 
 on:
   push:
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
 
       - if: ${{ steps.cache-go-deps.outputs.cache-hit != 'true' }}
-        name: List the state of node modules
+        name: List the state of go modules
         continue-on-error: true
         run: go mod graph
 
@@ -44,3 +44,8 @@ jobs:
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
+
+      - name: Run tests
+        run: |
+          go test ./...
+

--- a/cmd/ui/textinput/textinput.go
+++ b/cmd/ui/textinput/textinput.go
@@ -40,14 +40,13 @@ type model struct {
 }
 
 // sanitizeInput verifies that an input text string gets validated
-func sanitizeInput (input string) error {
-    matched, err := regexp.Match("^[a-zA-Z0-9_-]+$", []byte(input))
-    if !matched{
-        return fmt.Errorf("string violates the input regex pattern, err: %v", err);
-    }
-    return nil
+func sanitizeInput(input string) error {
+	matched, err := regexp.Match("^[a-zA-Z0-9_-]+$", []byte(input))
+	if !matched {
+		return fmt.Errorf("string violates the input regex pattern, err: %v", err)
+	}
+	return nil
 }
-
 
 // InitialTextInputModel initializes a textinput step
 // with the given data
@@ -56,7 +55,7 @@ func InitialTextInputModel(output *Output, header string, program *program.Proje
 	ti.Focus()
 	ti.CharLimit = 156
 	ti.Width = 20
-    ti.Validate = sanitizeInput
+	ti.Validate = sanitizeInput
 
 	return model{
 		textInput: ti,

--- a/cmd/ui/textinput/textinput.go
+++ b/cmd/ui/textinput/textinput.go
@@ -4,6 +4,7 @@ package textinput
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -38,6 +39,16 @@ type model struct {
 	exit      *bool
 }
 
+// sanitizeInput verifies that an input text string gets validated
+func sanitizeInput (input string) error {
+    matched, err := regexp.Match("^[a-zA-Z0-9_-]+$", []byte(input))
+    if !matched{
+        return fmt.Errorf("string violates the input regex pattern, err: %v", err);
+    }
+    return nil
+}
+
+
 // InitialTextInputModel initializes a textinput step
 // with the given data
 func InitialTextInputModel(output *Output, header string, program *program.Project) model {
@@ -45,6 +56,7 @@ func InitialTextInputModel(output *Output, header string, program *program.Proje
 	ti.Focus()
 	ti.CharLimit = 156
 	ti.Width = 20
+    ti.Validate = sanitizeInput
 
 	return model{
 		textInput: ti,

--- a/cmd/ui/textinput/textinput_test.go
+++ b/cmd/ui/textinput/textinput_test.go
@@ -1,34 +1,31 @@
 package textinput
 
-
 import "testing"
 
-
-
 func TestInputSanitization(t *testing.T) {
-    passTestCases := []string{
-        "chi",
-        "new_project",
-        "NEW_PROJECT",
-        "new-project",
-    }
-    for _, testCase := range passTestCases {
-        if err := sanitizeInput(testCase); err != nil {
-            t.Errorf("expected no error, got: %v", err);
-        }
-    }
-    failTestCases := []string{
-        "new project",
-        "NEW\\PROJECT",
-        "new%project",
-        " ",
-        "  ",
-        "#",
-        "@",
-    }
-    for _, testCase := range failTestCases {
-        if err := sanitizeInput(testCase); err == nil {
-            t.Errorf("expected error for input %v, got nil", testCase);
-        }
-    }
+	passTestCases := []string{
+		"chi",
+		"new_project",
+		"NEW_PROJECT",
+		"new-project",
+	}
+	for _, testCase := range passTestCases {
+		if err := sanitizeInput(testCase); err != nil {
+			t.Errorf("expected no error, got: %v", err)
+		}
+	}
+	failTestCases := []string{
+		"new project",
+		"NEW\\PROJECT",
+		"new%project",
+		" ",
+		"  ",
+		"#",
+		"@",
+	}
+	for _, testCase := range failTestCases {
+		if err := sanitizeInput(testCase); err == nil {
+			t.Errorf("expected error for input %v, got nil", testCase)
+		}
+	}
 }

--- a/cmd/ui/textinput/textinput_test.go
+++ b/cmd/ui/textinput/textinput_test.go
@@ -1,0 +1,34 @@
+package textinput
+
+
+import "testing"
+
+
+
+func TestInputSanitization(t *testing.T) {
+    passTestCases := []string{
+        "chi",
+        "new_project",
+        "NEW_PROJECT",
+        "new-project",
+    }
+    for _, testCase := range passTestCases {
+        if err := sanitizeInput(testCase); err != nil {
+            t.Errorf("expected no error, got: %v", err);
+        }
+    }
+    failTestCases := []string{
+        "new project",
+        "NEW\\PROJECT",
+        "new%project",
+        " ",
+        "  ",
+        "#",
+        "@",
+    }
+    for _, testCase := range failTestCases {
+        if err := sanitizeInput(testCase); err == nil {
+            t.Errorf("expected error for input %v, got nil", testCase);
+        }
+    }
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

I can pass two or more spaces as a project name causing it to fail. In the same way I can pass special characters that can mess with the integrity of the target file tree.

## Description of Changes: 

- Added function sanitizeInput. Leveraged [bubbles input Validate](https://pkg.go.dev/github.com/charmbracelet/bubbles@v0.16.1/textinput#Model.Validate) field to use said function.
- Added unit tests to the function.
- Modified linting.yml file to do continuous integration (linting and testing)

## Checklist

- [X] I have self-reviewed the changes being requested
- [X] I have updated the documentation (if applicable)
