### PR TITLE
feat: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Thanks for helping make the Twitch CLI better! 
+- [Contributing](#contributing)
+  - [Design Principles](#design-principles)
+  - [Report an Issue](#report-an-issue)
+  - [Contributing Code with Pull Requests](#contributing-code-with-pull-requests)
+    - [Requirements](#requirements)
+  - [Licensing](#licensing)
+
+## Design Principles
+
+Contributions to the go-blueprint should align with the project’s design principles:
+
+ * Maintain backwards compatibility whenever possible.
+
+## Report an Issue
+
+If you have run into a bug or want to discuss a new feature, please [file an issue](https://github.com/Melkeydev/go-blueprint/issues).
+
+## Contributing Code with Pull Requests
+
+go-blueprint uses [Github pull requests](https://github.com/Melkeydev/go-blueprint/pulls). Feel free to fork, hack away at your changes and submit.
+
+### Requirements
+
+ *  All commands and functionality should be documented appropriately
+ *  All new functionality/features should have appropriate unit testing 
+
+go-blueprint strives to have a consistent set of documentation that matches the command structure and any new functionality must have accompanying documentation in the PR.
+
+## Licensing
+
+See the [LICENSE](https://github.com/melkeydev/go-blueprint/blob/main/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for helping make the Twitch CLI better! 
+Thanks for helping make the go-blueprint better! 
 - [Contributing](#contributing)
   - [Design Principles](#design-principles)
   - [Report an Issue](#report-an-issue)


### PR DESCRIPTION
**This is a work in progress and will seek feedback do not merge**

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The project does not have a contributing guide that helps people getting started adding their own contributions to the project.

## Description of Changes: 

- Add a contribution guide.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
