### PR TITLE
Fix: use last selected choice

### DIFF
--- a/cmd/ui/multiInput/multiInput.go
+++ b/cmd/ui/multiInput/multiInput.go
@@ -89,7 +89,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "y":
 			if len(m.selected) == 1 {
-				m.choice.Update(m.choices[m.cursor].Title)
+				for selectedKey := range m.selected {
+					m.choice.Update(m.choices[selectedKey].Title)
+					m.cursor = selectedKey
+				}
 				return m, tea.Quit
 			}
 		}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

- fixes issue #116 

## Description of Changes: 

When pressing y to confirm choice of framework / db driver:
- use the last selected choice and not the one where the cursor currently is
- move the cursor to the last selected choice to display more clearly which one was chosen

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
