### PR TITLE
Fix selection

### DIFF
--- a/cmd/ui/multiInput/multiInput.go
+++ b/cmd/ui/multiInput/multiInput.go
@@ -89,7 +89,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "y":
 			if len(m.selected) == 1 {
-				m.choice.Update(m.choices[m.cursor].Title)
+				selectedKey := make([]int, 0, len(m.selected))
+                for k := range m.selected {
+                    selectedKey = append(selectedKey, k)
+                }
+				m.choice.Update(m.choices[selectedKey[0]].Title)
 				return m, tea.Quit
 			}
 		}

--- a/cmd/ui/multiInput/multiInput.go
+++ b/cmd/ui/multiInput/multiInput.go
@@ -89,16 +89,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "y":
 			if len(m.selected) == 1 {
-				selectedKey := make([]int, 0, len(m.selected))
-                for k := range m.selected {
-                    selectedKey = append(selectedKey, k)
-                }
-				m.choice.Update(m.choices[selectedKey[0]].Title)
+				for selectedKey := range m.selected {
+					m.choice.Update(m.choices[selectedKey].Title)
+					m.cursor = selectedKey
+				}
 				return m, tea.Quit
 			}
 		}
 	}
-	return m, nil
+    return m, nil
 }
 
 // View is called to draw the multiInput step


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Blueprint selects the framework/database where the user cursor is rather than the selected framework/database (#116) 

## Description of Changes: 

- Changed the Update function in multiInput.go to pass the selected framework/database

## Checklist

- [X ] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
