### PR TITLE
fix: change cmd in .air.toml to build instead of run

### DIFF
--- a/cmd/template/framework/files/air.toml.tmpl
+++ b/cmd/template/framework/files/air.toml.tmpl
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = []
   bin = "./tmp/main"
-  cmd = "make run"
+  cmd = "make build"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]
   exclude_file = []

--- a/cmd/template/framework/files/air.toml.tmpl
+++ b/cmd/template/framework/files/air.toml.tmpl
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = []
   bin = "./tmp/main"
-  cmd = "make build"
+  cmd = "go build -o ./tmp/main ./cmd/api"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]
   exclude_file = []

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -5,7 +5,7 @@ all: build
 
 build:
 	@echo "Building..."
-	@go build -o main cmd/api/main.go
+	@go build -o tmp/main cmd/api/main.go
 
 # Run the application
 run:
@@ -19,7 +19,7 @@ test:
 # Clean the binary
 clean:
 	@echo "Cleaning..."
-	@rm -f main
+	@rm -f tmp/main
 
 # Live Reload
 watch:

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -5,7 +5,7 @@ all: build
 
 build:
 	@echo "Building..."
-	@go build -o tmp/main cmd/api/main.go
+	@go build -o main cmd/api/main.go
 
 # Run the application
 run:
@@ -19,7 +19,7 @@ test:
 # Clean the binary
 clean:
 	@echo "Cleaning..."
-	@rm -f tmp/main
+	@rm -f main
 
 # Live Reload
 watch:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Prior to this commit, running `make watch` will result in the program running in the background without any way of killing it other than looking for its PID and killing that. This changes the "cmd" in the ".air.toml" file to run `go build -o ./tmp/main ./cmd/api` instead of `make run`.

Running `make watch` prior to this commit:
<img width="511" alt="image" src="https://github.com/Melkeydev/go-blueprint/assets/61931072/a1342db7-c1b4-46f4-91f2-6a9a345c0366">

It is stuck on "building..." but the program is already running in the background. ctrl+c kills air but does not kill the program running.

Running `make watch` with this commit:
<img width="518" alt="image" src="https://github.com/Melkeydev/go-blueprint/assets/61931072/fa5d5797-f80d-45ca-a3e2-5bfd534b61e7">

program is now running as expected and doing ctrl+c kills the program properly.

## Description of Changes: 

- Change `cmd` in `.air.toml` to ~`make build`~ `go build -o ./tmp/main ./cmd/api`
- ~Change `make build`'s output to `tmp/main` instead of `main`~

## Checklist

- [x] I have self-reviewed the changes being requested
