### PR TITLE
Fix: struct with 24 pointer bytes could be 16

### DIFF
--- a/cmd/template/framework/files/dbServer/standard_library.go.tmpl
+++ b/cmd/template/framework/files/dbServer/standard_library.go.tmpl
@@ -12,8 +12,8 @@ import (
 )
 
 type Server struct {
-	port int
 	db   database.Service
+	port int
 }
 
 func NewServer() *http.Server {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Please include a description of the problem or feature this PR is addressing.

## Description of Changes: 

Fixed the following warning:

Diagnostics:
1. struct with 24 pointer bytes could be 16 [default]

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
