### PR TITLE
fix: Missing argument [command] in non-interactive command tip

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -166,7 +166,7 @@ var createCmd = &cobra.Command{
 		fmt.Println(endingMsgStyle.Render(fmt.Sprintf("• cd %s\n", project.ProjectName)))
 
 		if isInteractive {
-			nonInteractiveCommand := utils.NonInteractiveCommand(cmd.Flags())
+			nonInteractiveCommand := utils.NonInteractiveCommand(cmd.Use, cmd.Flags())
 			fmt.Println(tipMsgStyle.Render("Tip: Repeat the equivalent Blueprint with the following non-interactive command:"))
 			fmt.Println(tipMsgStyle.Italic(false).Render(fmt.Sprintf("• %s\n", nonInteractiveCommand)))
 		}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -14,8 +14,8 @@ const ProgramName = "go-blueprint"
 
 // NonInteractiveCommand creates the command string from a flagSet
 // to be used for getting the equivalent non-interactive shell command
-func NonInteractiveCommand(flagSet *pflag.FlagSet) string {
-	nonInteractiveCommand := ProgramName
+func NonInteractiveCommand(use string, flagSet *pflag.FlagSet) string {
+	nonInteractiveCommand := fmt.Sprintf("%s %s", ProgramName, use)
 
 	visitFn := func(flag *pflag.Flag) {
 		if flag.Name != "help" {

--- a/contributors.yml
+++ b/contributors.yml
@@ -17,3 +17,4 @@
 - mimatache
 - muandane
 - SputNikPlop
+- Yoquec


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

When creating a new project without specifying any arguments, the non-interactive command tip showed at the end was missing the sub command (create, help, etc).

For example, before:
```
$ go-blueprint create
 ____  _                       _       _
|  _ \| |                     (_)     | |
| |_) | |_   _  ___ _ __  _ __ _ _ __ | |_
|  _ <| | | | |/ _ \ '_ \| '__| | '_ \| __|
| |_) | | |_| |  __/ |_) | |  | | | | | |_
|____/|_|\__,_|\___| .__/|_|  |_|_| |_|\__|
                   | |
                   |_|


 What is the name of your project?

...

 Tip: Repeat the equivalent Blueprint with the following non-interactive command:
 • go-blueprint --name test --framework echo --driver none
```
When repeating the command `go-blueprint --name test --framework echo --driver none` it wouldn't create the project structure, as the word `create` was missing.

Now, the output is:
```
 Tip: Repeat the equivalent Blueprint with the following non-interactive command:
 • go-blueprint create --name test --framework echo --driver none
```

## Description of Changes: 

- Fixes non-interactive command tip message at the end of the create command.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)[does not apply]
