### PR TITLE
Fix/air: Deprecated $GOPATH reliability

### DIFF
--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -23,15 +23,15 @@ clean:
 
 # Live Reload
 watch:
-	@if [ -x "$(GOPATH)/bin/air" ]; then \
-	    "$(GOPATH)/bin/air"; \
-		@echo "Watching...";\
+	@if command -v air > /dev/null; then \
+	    air; \
+	    echo "Watching...";\
 	else \
-	    read -p "air is not installed. Do you want to install it now? (y/n) " choice; \
-	    if [ "$$choice" = "y" ]; then \
-			go install github.com/cosmtrek/air@latest; \
-	        "$(GOPATH)/bin/air"; \
-				@echo "Watching...";\
+	    read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
+	    if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
+	        go install github.com/cosmtrek/air@latest; \
+	        air; \
+	        echo "Watching...";\
 	    else \
 	        echo "You chose not to install air. Exiting..."; \
 	        exit 1; \


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Closes #74;
Closes #111;

## Description of Changes: 

- Changed `make watch` to rely on command null command respons instead to check if `air` is installed of checking for GOPATH.

## Checklist

- [X] I have self-reviewed the changes being requested