### PR TITLE
Add advanced flag option

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -43,7 +43,8 @@ func init() {
 
 	createCmd.Flags().StringP("name", "n", "", "Name of project to create")
 	createCmd.Flags().VarP(&flagFramework, "framework", "f", fmt.Sprintf("Framework to use. Allowed values: %s", strings.Join(flags.AllowedProjectTypes, ", ")))
-	createCmd.Flags().VarP(&flagDBDriver, "driver", "d", fmt.Sprintf("database drivers to use. Allowed values: %s", strings.Join(flags.AllowedDBDrivers, ", ")))
+	createCmd.Flags().VarP(&flagDBDriver, "driver", "d", fmt.Sprintf("Database drivers to use. Allowed values: %s", strings.Join(flags.AllowedDBDrivers, ", ")))
+	createCmd.Flags().BoolP("advanced", "a", false, "Get prompts for advanced features")
 }
 
 type Options struct {
@@ -144,6 +145,15 @@ var createCmd = &cobra.Command{
 			if err != nil {
 				log.Fatal("failed to set the driver flag value", err)
 			}
+		}
+
+		flagAdvanced, err := cmd.Flags().GetBool("advanced")
+		if err != nil {
+			log.Fatal("failed to retrieve advanced flag")
+		}
+		if flagAdvanced {
+			fmt.Println("unimplemented")
+			// TODO: Add advanced input options. (HTMX/Templ etc.)
 		}
 
 		currentWorkingDir, err := os.Getwd()

--- a/cmd/steps/steps.go
+++ b/cmd/steps/steps.go
@@ -86,6 +86,10 @@ func InitSteps(projectType flags.Framework, databaseType flags.Database) *Steps 
 				Headers: "What database driver do you want to use in your Go project?",
 				Field:   databaseType.String(),
 			},
+			"advanced": {
+				StepName: "Advanced Features",
+				Headers:  "Do you want to choose from the advanced features?",
+			},
 		},
 	}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

This is just the foundation to add more advanced features referenced in [this issue](https://github.com/Melkeydev/go-blueprint/issues/125). I wanted to get this in to make sure I was on the right track with where we want this to go. 

## Description of Changes: 

- Adds an optional `--advanced` or `-a` flag to the `create` command. 
- I didn't add anything to the README yet, pending approval on the direction. 

I was thinking we might want to wait to merge this until we get one advanced feature added. Maybe we make an 'advanced' branch that we can merge into? 


## Checklist

- [ ] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
