### PR TITLE
Include error message in panic output in main

### DIFF
--- a/cmd/template/framework/files/main/fiber_main.go.tmpl
+++ b/cmd/template/framework/files/main/fiber_main.go.tmpl
@@ -17,6 +17,6 @@ func main() {
 	port, _ := strconv.Atoi(os.Getenv("PORT"))
 	err := server.Listen(fmt.Sprintf(":%d", port))
 	if err != nil {
-		panic("cannot start server")
+		panic(fmt.Sprintf("cannot start server: %s", err))
 	}
 }

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -10,6 +10,6 @@ func main() {
 
 	err := server.ListenAndServe()
 	if err != nil {
-		panic("cannot start server")
+		panic(fmt.Sprintf("cannot start server: %s", err))
 	}
 }

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"{{.ProjectName}}/internal/server"
 )
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature
Ran into an issue where port 8080 was already in use but the output only gave me the "cannot start server" message.

## Description of Changes: 

Added string formatting to panic output in main to include the error message if startup fails.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
