### PR TITLE
[Enhancement]: Use fiber.Map instead of map object

### DIFF
--- a/cmd/template/framework/files/routes/fiber.go.tmpl
+++ b/cmd/template/framework/files/routes/fiber.go.tmpl
@@ -9,7 +9,7 @@ func (s *FiberServer) RegisterFiberRoutes() {
 }
 
 func (s *FiberServer) HelloWorldHandler(c *fiber.Ctx) error {
-	resp := map[string]string{
+	resp := fiber.Map{
 		"message": "Hello World",
 	}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

GoFiber package recommends using fiber.Map{} type which is an alias of map interface for easier JSON handling.

## Description of Changes: 

- Changed `map[string]string` type for `HelloWorldHandler` response to standard `fiber.Map{}` as recommended by the package.

## Checklist

- [X] I have self-reviewed the changes being requested
- [X] I have updated the documentation (if applicable)
