### PR TITLE
fix: release terminal

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -209,6 +209,7 @@ var createCmd = &cobra.Command{
 		err = project.CreateMainFile()
 		if err != nil {
 			log.Printf("Problem creating files for project. %v", err)
+			spinner.ReleaseTerminal()
 			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 		}
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -208,8 +208,10 @@ var createCmd = &cobra.Command{
 		// This calls the templates
 		err = project.CreateMainFile()
 		if err != nil {
+			if releaseErr := spinner.ReleaseTerminal(); releaseErr != nil {
+				log.Printf("Problem releasing terminal: %v", releaseErr)
+			}
 			log.Printf("Problem creating files for project. %v", err)
-			spinner.ReleaseTerminal()
 			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 		}
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Fix terminal not getting released if there is an error from `project.CreateMainFile()`
for example #159 

## Description of Changes: 

- Add `spinner.ReleaseTerminal()` as part of the error handling for `project.CreateMainFile()`

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
