### PR TITLE
Added templ generated files in gitignore

### DIFF
--- a/cmd/template/framework/files/gitignore.tmpl
+++ b/cmd/template/framework/files/gitignore.tmpl
@@ -24,3 +24,6 @@ tmp/
 
 # .env file
 .env
+
+# templ generated files
+**/*_templ.go


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The gitignore template does not exclude the generated templ files. In my opinion, this should be excluded from VCS. 

I'm not very sure about what "best practice" dictates here, but to me it makes sense that generated files should not be in version control and should be generated everytime?

Sorry if this is an unwelcome change because it's so small, but I think I add it everytime I use it, so figured it might be worth just making a PR for it.

## Description of Changes: 

- Added the regex for excluding any files of files ending with `_templ.go`.

## Checklist

- [X] I have self-reviewed the changes being requested
- [X] I have updated the documentation (if applicable)
