### PR TITLE
fix: Adding templ specific config to air.toml

### DIFF
--- a/cmd/template/framework/files/air.toml.tmpl
+++ b/cmd/template/framework/files/air.toml.tmpl
@@ -4,17 +4,17 @@ tmp_dir = "tmp"
 
 [build]
   args_bin = []
-  bin = "./tmp/main"
-  cmd = "go build -o ./tmp/main ./cmd/api"
+  bin = "./main"
+  cmd = "make build"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]
   exclude_file = []
-  exclude_regex = ["_test.go"]
+  exclude_regex = ["_test.go"{{if .AdvancedOptions.AddHTMXTempl}}, ".*_templ.go"{{end}}]
   exclude_unchanged = false
   follow_symlink = false
   full_bin = ""
   include_dir = []
-  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_ext = ["go", "tpl", "tmpl", "html"{{if .AdvancedOptions.AddHTMXTempl}}, "templ"{{end}}]
   include_file = []
   kill_delay = "0s"
   log = "build-errors.log"

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -5,6 +5,7 @@ all: build
 
 build:
 	@echo "Building..."
+	{{if .AdvancedOptions.AddHTMXTempl}}@templ generate{{end}}
 	@go build -o main cmd/api/main.go
 
 # Run the application

--- a/cmd/template/framework/files/nondbMakeFile.tmpl
+++ b/cmd/template/framework/files/nondbMakeFile.tmpl
@@ -5,6 +5,7 @@ all: build
 
 build:
 	@echo "Building..."
+	{{if .AdvancedOptions.AddHTMXTempl}}@templ generate{{end}}
 	@go build -o main cmd/api/main.go
 
 # Run the application


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Adding templ specific config to the files watched by air and also ensuring that the makefile commands are used for air.
Currently there is not a lot of complexity in the build process but as configuration increases, I would assume the team would want the makefile command to be the source of truth.
Resolves #171

## Description of Changes: 

- Added regex to ignore _templ.go files
- Added .templ files to the air toml
- Added `templ generate` to the makefiles conditionally

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
