### PR TITLE
Add a deferred anonymous function to release on panic

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -207,7 +207,8 @@ var createCmd = &cobra.Command{
 
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Println("Recovered from panic:", r)
+				fmt.Println("The program encountered an unexpected issue and had to exit. The error was:", r)
+				fmt.Println("If you continue to experience this issue, please post a message on our GitHub page or join our Discord server for support.")
 				if releaseErr := spinner.ReleaseTerminal(); releaseErr != nil {
 					log.Printf("Problem releasing terminal: %v", releaseErr)
 				}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -205,6 +205,15 @@ var createCmd = &cobra.Command{
 			}
 		}()
 
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Println("Recovered from panic:", r)
+				if releaseErr := spinner.ReleaseTerminal(); releaseErr != nil {
+					log.Printf("Problem releasing terminal: %v", releaseErr)
+				}
+			}
+		}()
+
 		// This calls the templates
 		err = project.CreateMainFile()
 		if err != nil {

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -219,7 +219,9 @@ func (p *Project) CreateMainFile() error {
 		cobra.CheckErr(err)
 	}
 	if !nameSet {
-		log.Fatal("user.name is not set in git config")
+		fmt.Println("user.name is not set in git config.")
+		fmt.Println("Please set up git config before trying again.")
+		panic("\nGIT CONFIG ISSUE: user.name is not set in git config.\n")
 	}
 
 	// Check if user.email is set.
@@ -228,7 +230,9 @@ func (p *Project) CreateMainFile() error {
 		cobra.CheckErr(err)
 	}
 	if !emailSet {
-		log.Fatal("user.email is not set in git config")
+		fmt.Println("user.email is not set in git config.")
+		fmt.Println("Please set up git config before trying again.")
+		panic("\nGIT CONFIG ISSUE: user.email is not set in git config.\n")
 	}
 
 	p.ProjectName = strings.TrimSpace(p.ProjectName)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Attempted fix for #175 

## Description of Changes: 

- I added a deferred anonymous function to check if the program panicked. If it did, it releases the terminal.
- I also added a panic to the git config check if they are not present. That combined with the deferred function mentioned previously, we shouldn't have users run into issues where the terminal doesn't release on panic.


## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
