### PR TITLE
Add websocket endpoint to advanced options

### DIFF
--- a/cmd/steps/steps.go
+++ b/cmd/steps/steps.go
@@ -103,6 +103,11 @@ func InitSteps(projectType flags.Framework, databaseType flags.Database) *Steps 
 						Title: "Go Project Workflow",
 						Desc:  "Workflow templates for testing, cross-compiling and releasing Go projects",
 					},
+					{
+						Flag:  "Websocket",
+						Title: "Weboscket endpoint",
+						Desc:  "Add a websocket endpoint",
+					},
 				},
 			},
 		},

--- a/cmd/template/advanced/files/websocket/imports/fiber.tmpl
+++ b/cmd/template/advanced/files/websocket/imports/fiber.tmpl
@@ -1,0 +1,1 @@
+"github.com/gofiber/contrib/websocket"

--- a/cmd/template/advanced/files/websocket/imports/standard_library.tmpl
+++ b/cmd/template/advanced/files/websocket/imports/standard_library.tmpl
@@ -1,0 +1,1 @@
+"nhooyr/websocket"

--- a/cmd/template/advanced/routes.go
+++ b/cmd/template/advanced/routes.go
@@ -31,6 +31,9 @@ var stdLibHtmxTemplRoutes []byte
 //go:embed files/htmx/imports/standard_library.tmpl
 var stdLibHtmxTemplImports []byte
 
+//go:embed files/websocket/imports/standard_library.tmpl
+var stdLibWebsocketImports []byte
+
 //go:embed files/htmx/routes/chi.tmpl
 var chiHtmxTemplRoutes []byte
 
@@ -48,6 +51,10 @@ var fiberHtmxTemplRoutes []byte
 
 //go:embed files/htmx/imports/fiber.tmpl
 var fiberHtmxTemplImports []byte
+
+//go:embed files/websocket/imports/fiber.tmpl
+var fiberWebsocketTemplImports []byte
+
 
 func EchoHtmxTemplRoutesTemplate() []byte {
 	return echoHtmxTemplRoutes
@@ -75,6 +82,10 @@ func StdLibHtmxTemplRoutesTemplate() []byte {
 
 func StdLibHtmxTemplImportsTemplate() []byte {
 	return stdLibHtmxTemplImports
+}
+
+func StdLibWebsocketTemplImportsTemplate() []byte {
+	return stdLibWebsocketImports
 }
 
 func HelloTemplTemplate() []byte {
@@ -108,3 +119,8 @@ func FiberHtmxTemplRoutesTemplate() []byte {
 func FiberHtmxTemplImportsTemplate() []byte {
 	return fiberHtmxTemplImports
 }
+
+func FiberWebsocketTemplImportsTemplate() []byte {
+	return fiberWebsocketTemplImports
+}
+

--- a/cmd/template/framework/chiRoutes.go
+++ b/cmd/template/framework/chiRoutes.go
@@ -39,3 +39,7 @@ func (c ChiTemplates) HtmxTemplImports() []byte {
 func (c ChiTemplates) HtmxTemplRoutes() []byte {
 	return advanced.ChiHtmxTemplRoutesTemplate()
 }
+
+func (c ChiTemplates) WebsocketImports() []byte {
+	return advanced.StdLibWebsocketTemplImportsTemplate()
+}

--- a/cmd/template/framework/echoRoutes.go
+++ b/cmd/template/framework/echoRoutes.go
@@ -38,3 +38,7 @@ func (e EchoTemplates) HtmxTemplImports() []byte {
 func (e EchoTemplates) HtmxTemplRoutes() []byte {
 	return advanced.EchoHtmxTemplRoutesTemplate()
 }
+
+func (e EchoTemplates) WebsocketImports() []byte {
+	return advanced.StdLibWebsocketTemplImportsTemplate()
+}

--- a/cmd/template/framework/fiberServer.go
+++ b/cmd/template/framework/fiberServer.go
@@ -44,3 +44,7 @@ func (f FiberTemplates) HtmxTemplImports() []byte {
 func (f FiberTemplates) HtmxTemplRoutes() []byte {
 	return advanced.FiberHtmxTemplRoutesTemplate()
 }
+
+func (f FiberTemplates) WebsocketImports() []byte {
+	return advanced.FiberWebsocketTemplImportsTemplate()
+}

--- a/cmd/template/framework/files/routes/chi.go.tmpl
+++ b/cmd/template/framework/files/routes/chi.go.tmpl
@@ -19,6 +19,9 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{if ne .DBDriver "none"}}
 	r.Get("/health", s.healthHandler)
   {{end}}
+  {{if .AdvancedOptions.Websocket}}
+	r.Get("/websocket", s.websocketHandler)
+  {{end}}
   {{.AdvancedTemplates.TemplateRoutes}}
 
 	return r
@@ -40,5 +43,44 @@ func (s *Server) HelloWorldHandler(w http.ResponseWriter, r *http.Request) {
 func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	jsonResp, _ := json.Marshal(s.db.Health())
 	_, _ = w.Write(jsonResp)
+}
+{{end}}
+
+{{if .AdvancedOptions.Websocket}}
+func (s *Server) websocketHandler(w http.ResponseWriter, r *http.Request) {
+	errorMessage := []byte("This is another message not PING")
+	socket, err := websocket.Accept(w, r, nil)
+
+	if err != nil {
+		log.Print("could not open websocket")
+		_, _ = w.Write([]byte("could not open websocket"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer socket.Close(websocket.StatusGoingAway, "server closing websocket")
+
+	ctx := r.Context()
+	for {
+		msgType, socketBytes, err := socket.Read(ctx)
+
+		if err != nil {
+			log.Print("could not read from websocket")
+			return
+		}
+
+		if string(socketBytes) == "PING" {
+			if err := socket.Write(ctx, msgType, []byte("PONG")); err != nil {
+				log.Print("could not write to socket")
+				return
+			}
+			continue
+		}
+
+		if err := socket.Write(ctx, msgType, errorMessage); err != nil {
+			log.Print("could not write to socket")
+			return
+		}
+	}
 }
 {{end}}

--- a/cmd/template/framework/files/routes/echo.go.tmpl
+++ b/cmd/template/framework/files/routes/echo.go.tmpl
@@ -17,6 +17,9 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{if ne .DBDriver "none"}}
 	e.GET("/health", s.healthHandler)
   {{end}}
+  {{if .AdvancedOptions.Websocket}}
+	e.GET("/websocket", s.websocketHandler)
+  {{end}}
 
 	return e
 }
@@ -32,5 +35,46 @@ func (s *Server) HelloWorldHandler(c echo.Context) error {
 {{if ne .DBDriver "none"}}
 func (s *Server) healthHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, s.db.Health())
+}
+{{end}}
+
+{{if .AdvancedOptions.Websocket}}
+func (s *Server) websocketHandler(c echo.Context) {
+	w := c.Response().Writer
+	r := c.Request()
+	errorMessage := []byte("This is another message not PING")
+	socket, err := websocket.Accept(w, r, nil)
+
+	if err != nil {
+		log.Print("could not open websocket")
+		_, _ = w.Write([]byte("could not open websocket"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer socket.Close(websocket.StatusGoingAway, "server closing websocket")
+
+	ctx := r.Context()
+	for {
+		msgType, socketBytes, err := socket.Read(ctx)
+
+		if err != nil {
+			log.Print("could not read from websocket")
+			return
+		}
+
+		if string(socketBytes) == "PING" {
+			if err := socket.Write(ctx, msgType, []byte("PONG")); err != nil {
+				log.Print("could not write to socket")
+				return
+			}
+			continue
+		}
+
+		if err := socket.Write(ctx, msgType, errorMessage); err != nil {
+			log.Print("could not write to socket")
+			return
+		}
+	}
 }
 {{end}}

--- a/cmd/template/framework/files/routes/fiber.go.tmpl
+++ b/cmd/template/framework/files/routes/fiber.go.tmpl
@@ -10,6 +10,9 @@ func (s *FiberServer) RegisterFiberRoutes() {
   {{if ne .DBDriver "none"}}
 	s.App.Get("/health", s.healthHandler)
   {{end}}
+  {{if .AdvancedOptions.Websocket}}
+	s.App.Get("/websocket", s.websocketHandler)
+  {{end}}
 
   {{.AdvancedTemplates.TemplateRoutes}}
 }
@@ -25,5 +28,30 @@ func (s *FiberServer) HelloWorldHandler(c *fiber.Ctx) error {
 {{if ne .DBDriver "none"}}
 func (s *FiberServer) healthHandler(c *fiber.Ctx) error {
 	return c.JSON(s.db.Health())
+}
+{{end}}
+
+{{if .AdvancedOptions.Websocket}}
+func (s *FiberServer) pingPongWebsocketHandler(c *fiber.Ctx) {
+	for {
+		messageType, socketBytes, err := con.ReadMessage()
+
+		if err != nil {
+			log.Print("could not read from websocket")
+			return
+		}
+
+		if string(socketBytes) == "PING" {
+			if err := con.WriteMessage(messageType, []byte("PONG")); err != nil {
+				log.Print("could not write to socket")
+				return
+			}
+		} else {
+			if err  := con.WriteMessage(messageType, []byte("HUH?")); err != nil {
+				log.Print("could not write to socket")
+				return
+			}
+		}
+	}
 }
 {{end}}

--- a/cmd/template/framework/files/routes/gin.go.tmpl
+++ b/cmd/template/framework/files/routes/gin.go.tmpl
@@ -15,6 +15,9 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{if ne .DBDriver "none"}}
 	r.GET("/health", s.healthHandler)
   {{end}}
+  {{if .AdvancedOptions.Websocket}}
+	r.GET("/websocket", s.websocketHandler)
+  {{end}}
 
   {{.AdvancedTemplates.TemplateRoutes}}
 
@@ -31,5 +34,47 @@ func (s *Server) HelloWorldHandler(c *gin.Context) {
 {{if ne .DBDriver "none"}}
 func (s *Server) healthHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, s.db.Health())
+}
+{{end}}
+
+
+{{if .AdvancedOptions.Websocket}}
+func (s *Server) websocketHandler(c *gin.Context) {
+	w := c.Writer
+	r := c.Request
+	errorMessage := []byte("This is another message not PING")
+	socket, err := websocket.Accept(w, r, nil)
+
+	if err != nil {
+		log.Print("could not open websocket")
+		_, _ = w.Write([]byte("could not open websocket"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer socket.Close(websocket.StatusGoingAway, "server closing websocket")
+
+	ctx := r.Context()
+	for {
+		msgType, socketBytes, err := socket.Read(ctx)
+
+		if err != nil {
+			log.Print("could not read from websocket")
+			return
+		}
+
+		if string(socketBytes) == "PING" {
+			if err := socket.Write(ctx, msgType, []byte("PONG")); err != nil {
+				log.Print("could not write to socket")
+				return
+			}
+			continue
+		}
+
+		if err := socket.Write(ctx, msgType, errorMessage); err != nil {
+			log.Print("could not write to socket")
+			return
+		}
+	}
 }
 {{end}}

--- a/cmd/template/framework/files/routes/gorilla.go.tmpl
+++ b/cmd/template/framework/files/routes/gorilla.go.tmpl
@@ -16,6 +16,9 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{if ne .DBDriver "none"}}
 	r.HandleFunc("/health", s.healthHandler)
   {{end}}
+  {{if .AdvancedOptions.Websocket}}
+	r.HandleFunc("/websocket", s.websocketHandler)
+  {{end}}
 
   {{.AdvancedTemplates.TemplateRoutes}}
 
@@ -43,5 +46,44 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, _ = w.Write(jsonResp)
+}
+{{end}}
+
+{{if .AdvancedOptions.Websocket}}
+func (s *Server) pingPongWebsocketHandler(w http.ResponseWriter, r *http.Request) {
+	errorMessage := []byte("This is another message not PING")
+	socket, err := websocket.Accept(w, r, nil)
+
+	if err != nil {
+		log.Print("could not open websocket")
+		_, _ = w.Write([]byte("could not open websocket"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer socket.Close(websocket.StatusGoingAway, "server closing websocket")
+
+	ctx := r.Context()
+	for {
+		msgType, socketBytes, err := socket.Read(ctx)
+
+		if err != nil {
+			log.Print("could not read from websocket")
+			return
+		}
+
+		if string(socketBytes) == "PING" {
+			if err := socket.Write(ctx, msgType, []byte("PONG")); err != nil {
+				log.Print("could not write to socket")
+				return
+			}
+			continue
+		}
+
+		if err := socket.Write(ctx, msgType, errorMessage); err != nil {
+			log.Print("could not write to socket")
+			return
+		}
+	}
 }
 {{end}}

--- a/cmd/template/framework/files/routes/http_router.go.tmpl
+++ b/cmd/template/framework/files/routes/http_router.go.tmpl
@@ -16,6 +16,9 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{if ne .DBDriver "none"}}
 	r.HandlerFunc(http.MethodGet, "/health", s.healthHandler)
   {{end}}
+  {{if .AdvancedOptions.Websocket}}
+	r.HandleFunc(http.MethodGet, "/websocket", s.websocketHandler)
+  {{end}}
   {{.AdvancedTemplates.TemplateRoutes}}
 
 	return r
@@ -42,5 +45,44 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, _ = w.Write(jsonResp)
+}
+{{end}}
+
+{{if .AdvancedOptions.Websocket}}
+func (s *Server) pingPongWebsocketHandler(w http.ResponseWriter, r *http.Request) {
+	errorMessage := []byte("This is another message not PING")
+	socket, err := websocket.Accept(w, r, nil)
+
+	if err != nil {
+		log.Print("could not open websocket")
+		_, _ = w.Write([]byte("could not open websocket"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer socket.Close(websocket.StatusGoingAway, "server closing websocket")
+
+	ctx := r.Context()
+	for {
+		msgType, socketBytes, err := socket.Read(ctx)
+
+		if err != nil {
+			log.Print("could not read from websocket")
+			return
+		}
+
+		if string(socketBytes) == "PING" {
+			if err := socket.Write(ctx, msgType, []byte("PONG")); err != nil {
+				log.Print("could not write to socket")
+				return
+			}
+			continue
+		}
+
+		if err := socket.Write(ctx, msgType, errorMessage); err != nil {
+			log.Print("could not write to socket")
+			return
+		}
+	}
 }
 {{end}}

--- a/cmd/template/framework/files/routes/standard_library.go.tmpl
+++ b/cmd/template/framework/files/routes/standard_library.go.tmpl
@@ -14,6 +14,9 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{if ne .DBDriver "none"}}
 	mux.HandleFunc("/health", s.healthHandler)
   {{end}}
+  {{if .AdvancedOptions.Websocket}}
+	r.HandleFunc(http.MethodGet, "/websocket", s.websocketHandler)
+  {{end}}
   {{.AdvancedTemplates.TemplateRoutes}}
 
 	return mux
@@ -40,5 +43,44 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, _ = w.Write(jsonResp)
+}
+{{end}}
+
+{{if .AdvancedOptions.Websocket}}
+func (s *Server) pingPongWebsocketHandler(w http.ResponseWriter, r *http.Request) {
+	errorMessage := []byte("This is another message not PING")
+	socket, err := websocket.Accept(w, r, nil)
+
+	if err != nil {
+		log.Print("could not open websocket")
+		_, _ = w.Write([]byte("could not open websocket"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	defer socket.Close(websocket.StatusGoingAway, "server closing websocket")
+
+	ctx := r.Context()
+	for {
+		msgType, socketBytes, err := socket.Read(ctx)
+
+		if err != nil {
+			log.Print("could not read from websocket")
+			return
+		}
+
+		if string(socketBytes) == "PING" {
+			if err := socket.Write(ctx, msgType, []byte("PONG")); err != nil {
+				log.Print("could not write to socket")
+				return
+			}
+			continue
+		}
+
+		if err := socket.Write(ctx, msgType, errorMessage); err != nil {
+			log.Print("could not write to socket")
+			return
+		}
+	}
 }
 {{end}}

--- a/cmd/template/framework/ginRoutes.go
+++ b/cmd/template/framework/ginRoutes.go
@@ -39,3 +39,7 @@ func (g GinTemplates) HtmxTemplImports() []byte {
 func (g GinTemplates) HtmxTemplRoutes() []byte {
 	return advanced.GinHtmxTemplRoutesTemplate()
 }
+
+func (g GinTemplates) WebsocketImports() []byte {
+	return advanced.StdLibWebsocketTemplImportsTemplate()
+}

--- a/cmd/template/framework/gorillaRoutes.go
+++ b/cmd/template/framework/gorillaRoutes.go
@@ -39,3 +39,7 @@ func (g GorillaTemplates) HtmxTemplImports() []byte {
 func (g GorillaTemplates) HtmxTemplRoutes() []byte {
 	return advanced.GorillaHtmxTemplRoutesTemplate()
 }
+
+func (g GorillaTemplates) WebsocketImports() []byte {
+	return advanced.StdLibWebsocketTemplImportsTemplate()
+}

--- a/cmd/template/framework/httpRoutes.go
+++ b/cmd/template/framework/httpRoutes.go
@@ -42,3 +42,7 @@ func (s StandardLibTemplate) HtmxTemplImports() []byte {
 func (s StandardLibTemplate) HtmxTemplRoutes() []byte {
 	return advanced.StdLibHtmxTemplRoutesTemplate()
 }
+
+func (s StandardLibTemplate) WebsocketImports() []byte {
+	return advanced.StdLibWebsocketTemplImportsTemplate()
+}

--- a/cmd/template/framework/routerRoutes.go
+++ b/cmd/template/framework/routerRoutes.go
@@ -38,3 +38,7 @@ func (r RouterTemplates) HtmxTemplImports() []byte {
 func (r RouterTemplates) HtmxTemplRoutes() []byte {
 	return advanced.HttpRouterHtmxTemplRoutesTemplate()
 }
+
+func (r RouterTemplates) WebsocketImports() []byte {
+	return advanced.StdLibWebsocketTemplImportsTemplate()
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Resolves #174 

## Description of Changes: 

This PR adds an option to the `--advanced` flag that let's users add a websocket endpoint to their `routes.go` file automatically.

#184 is still open so if that get's merged before this one, this pr will also include the flag option like that pr describes.

## Checklist

- [ ] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
