### PR TITLE
chore (Resolves #193): Add project build binary to `.gitignore`

### DIFF
--- a/cmd/template/framework/files/gitignore.tmpl
+++ b/cmd/template/framework/files/gitignore.tmpl
@@ -24,3 +24,6 @@ tmp/
 
 # .env file
 .env
+
+# Project build
+main


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature
Issue #193 

## Description of Changes: 

This PR updates the `.gitignore` file generated for projects to include the binary generated by Air

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
