### PR TITLE
Feat [Fiber Framework] ServerHeader and AppName depends of project name

### DIFF
--- a/cmd/template/framework/files/server/fiber.go.tmpl
+++ b/cmd/template/framework/files/server/fiber.go.tmpl
@@ -16,7 +16,10 @@ type FiberServer struct {
 
 func New() *FiberServer {
 	server := &FiberServer{
-		App: fiber.New(),
+		App: fiber.New(fiber.Config{
+		ServerHeader:            "{{.ProjectName}}",
+		AppName:                 "{{.ProjectName}}",
+	}),
   {{if ne .DBDriver "none"}}
 		db:  database.New(),
   {{end}}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Add ServerHeader and AppName depends of project name

> [!NOTE]  
> This a cool feature from fiber

## Description of Changes: 

Example how it work:

```sh
$ go-blueprint create --name my-project --framework fiber --driver mysql


 ____  _                       _       _   
|  _ \| |                     (_)     | |  
| |_) | |_   _  ___ _ __  _ __ _ _ __ | |_ 
|  _ <| | | | |/ _ \ '_ \| '__| | '_ \| __|
| |_) | | |_| |  __/ |_) | |  | | | | | |_ 
|____/|_|\__,_|\___| .__/|_|  |_|_| |_|\__|
                   | |
                   |_|


            ..
             Next steps:
                         • cd into the newly created project with: `cd my-project`

$ cd my-project

$ go run cmd/api/main.go

 ┌───────────────────────────────────────────────────┐ 
 │                    my-project                     │ 
 │                   Fiber v2.52.4                   │ 
 │               http://127.0.0.1:8080               │ 
 │       (bound on host 0.0.0.0 and port 8080)       │ 
 │                                                   │ 
 │ Handlers ............. 4  Processes ........... 1 │ 
 │ Prefork ....... Disabled  PID .............. 9732 │ 
 └───────────────────────────────────────────────────┘ 

```


## Checklist

- [X] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
