### PR TITLE
Implement [Database Template] [MySQL] [PostgreSQL] [SQLite] Close Database Connection

### DIFF
--- a/cmd/template/dbdriver/files/service/mysql.tmpl
+++ b/cmd/template/dbdriver/files/service/mysql.tmpl
@@ -13,8 +13,15 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 )
 
+// Service represents a service that interacts with a database.
 type Service interface {
+	// Health returns a map of health status information.
+	// The keys and values in the map are service-specific.
 	Health() map[string]string
+
+	// Close terminates the database connection.
+	// It returns an error if the connection cannot be closed.
+	Close() error
 }
 
 type service struct {
@@ -101,4 +108,13 @@ func (s *service) Health() map[string]string {
 	}
 
 	return stats
+}
+
+// Close closes the database connection.
+// It logs a message indicating the disconnection from the specific database.
+// If the connection is successfully closed, it returns nil.
+// If an error occurs while closing the connection, it returns the error.
+func (s *service) Close() error {
+	log.Printf("Disconnected from database: %s", dbname)
+	return s.db.Close()
 }

--- a/cmd/template/dbdriver/files/service/postgres.tmpl
+++ b/cmd/template/dbdriver/files/service/postgres.tmpl
@@ -109,6 +109,6 @@ func (s *service) Health() map[string]string {
 // If the connection is successfully closed, it returns nil.
 // If an error occurs while closing the connection, it returns the error.
 func (s *service) Close() error {
-	log.Printf("Disconnected from database: %s", DB_DATABASE)
+	log.Printf("Disconnected from database: %s", database)
 	return s.db.Close()
 }

--- a/cmd/template/dbdriver/files/service/postgres.tmpl
+++ b/cmd/template/dbdriver/files/service/postgres.tmpl
@@ -13,8 +13,15 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 )
 
+// Service represents a service that interacts with a database.
 type Service interface {
+	// Health returns a map of health status information.
+	// The keys and values in the map are service-specific.
 	Health() map[string]string
+
+	// Close terminates the database connection.
+	// It returns an error if the connection cannot be closed.
+	Close() error
 }
 
 type service struct {
@@ -95,4 +102,13 @@ func (s *service) Health() map[string]string {
 	}
 
 	return stats
+}
+
+// Close closes the database connection.
+// It logs a message indicating the disconnection from the specific database.
+// If the connection is successfully closed, it returns nil.
+// If an error occurs while closing the connection, it returns the error.
+func (s *service) Close() error {
+	log.Printf("Disconnected from database: %s", dbname)
+	return s.db.Close()
 }

--- a/cmd/template/dbdriver/files/service/postgres.tmpl
+++ b/cmd/template/dbdriver/files/service/postgres.tmpl
@@ -109,6 +109,6 @@ func (s *service) Health() map[string]string {
 // If the connection is successfully closed, it returns nil.
 // If an error occurs while closing the connection, it returns the error.
 func (s *service) Close() error {
-	log.Printf("Disconnected from database: %s", dbname)
+	log.Printf("Disconnected from database: %s", DB_DATABASE)
 	return s.db.Close()
 }

--- a/cmd/template/dbdriver/files/service/sqlite.tmpl
+++ b/cmd/template/dbdriver/files/service/sqlite.tmpl
@@ -108,6 +108,6 @@ func (s *service) Health() map[string]string {
 // If the connection is successfully closed, it returns nil.
 // If an error occurs while closing the connection, it returns the error.
 func (s *service) Close() error {
-	log.Printf("Disconnected from database: %s", dbname)
+	log.Printf("Disconnected from database: %s", dburl)
 	return s.db.Close()
 }

--- a/cmd/template/dbdriver/files/service/sqlite.tmpl
+++ b/cmd/template/dbdriver/files/service/sqlite.tmpl
@@ -13,8 +13,15 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 )
 
+// Service represents a service that interacts with a database.
 type Service interface {
+	// Health returns a map of health status information.
+	// The keys and values in the map are service-specific.
 	Health() map[string]string
+
+	// Close terminates the database connection.
+	// It returns an error if the connection cannot be closed.
+	Close() error
 }
 
 type service struct {
@@ -94,4 +101,13 @@ func (s *service) Health() map[string]string {
 	}
 
 	return stats
+}
+
+// Close closes the database connection.
+// It logs a message indicating the disconnection from the specific database.
+// If the connection is successfully closed, it returns nil.
+// If an error occurs while closing the connection, it returns the error.
+func (s *service) Close() error {
+	log.Printf("Disconnected from database: %s", dbname)
+	return s.db.Close()
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

By implementing this `Close Database Connection`, it can be useful in scenarios such as graceful shutdown, for example, in Kubernetes (k8s).

## Description of Changes: 

- [+] feat(mysql.tmpl): add Close() method to Service interface and its implementation
- [+] docs(mysql.tmpl): add comments for Service interface and its methods

Note: By using the "log.Printf" method, it is more concise and idiomatic Go.

## Checklist

- [X] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
