### PR TITLE
Redis-image-version

### DIFF
--- a/cmd/template/docker/files/docker-compose/redis.tmpl
+++ b/cmd/template/docker/files/docker-compose/redis.tmpl
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   redis:
-    image: redis:latest
+    image: redis:7.2.4
     restart: always
     ports:
       - "${DB_PORT}:6379"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

Limiting the Docker image to version before dual licensing

#202 
## Checklist

- [X] I have self-reviewed the changes being requested
- [X] I have updated the documentation (if applicable)
