### PR TITLE
move js/ into assets/js/ and make assets/ as static file server

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -426,19 +426,19 @@ func (p *Project) CreateMainFile() error {
 			return err
 		}
 
-		err = os.Mkdir(fmt.Sprintf("%s/%s/js", projectPath, cmdWebPath), 0755)
+		err = os.MkdirAll(fmt.Sprintf("%s/%s/assets/js", projectPath, cmdWebPath), 0755)
 		if err != nil {
 			cobra.CheckErr(err)
 		}
 
-		htmxMinJsFile, err := os.Create(fmt.Sprintf("%s/%s/js/htmx.min.js", projectPath, cmdWebPath))
+		htmxMinJsFile, err := os.Create(fmt.Sprintf("%s/%s/assets/js/htmx.min.js", projectPath, cmdWebPath))
 		if err != nil {
 			cobra.CheckErr(err)
 		}
 		defer htmxMinJsFile.Close()
 
 		htmxMinJsTemplate := advanced.HtmxJSTemplate()
-		err = os.WriteFile(fmt.Sprintf("%s/%s/js/htmx.min.js", projectPath, cmdWebPath), htmxMinJsTemplate, 0644)
+		err = os.WriteFile(fmt.Sprintf("%s/%s/assets/js/htmx.min.js", projectPath, cmdWebPath), htmxMinJsTemplate, 0644)
 		if err != nil {
 			return err
 		}

--- a/cmd/template/advanced/files/htmx/base.templ.tmpl
+++ b/cmd/template/advanced/files/htmx/base.templ.tmpl
@@ -6,7 +6,7 @@ templ Base() {
 		<head>
 			<meta charset="utf-8"/>
 			<title>Go Blueprint Hello</title>
-			<script src="/js/htmx.min.js"></script>
+			<script src="assets/js/htmx.min.js"></script>
 		</head>
 		<body>
 			<main>

--- a/cmd/template/advanced/files/htmx/efs.go.tmpl
+++ b/cmd/template/advanced/files/htmx/efs.go.tmpl
@@ -2,5 +2,5 @@ package web
 
 import "embed"
 
-//go:embed "js"
+//go:embed "assets"
 var Files embed.FS

--- a/cmd/template/advanced/files/htmx/routes/chi.tmpl
+++ b/cmd/template/advanced/files/htmx/routes/chi.tmpl
@@ -1,4 +1,4 @@
 fileServer := http.FileServer(http.FS(web.Files))
-	r.Handle("/js/*", fileServer)
+	r.Handle("/assets/*", fileServer)
 	r.Get("/web", templ.Handler(web.HelloForm()).ServeHTTP)
 	r.Post("/hello", web.HelloWebHandler)

--- a/cmd/template/advanced/files/htmx/routes/echo.tmpl
+++ b/cmd/template/advanced/files/htmx/routes/echo.tmpl
@@ -1,5 +1,5 @@
 fileServer := http.FileServer(http.FS(web.Files))
-e.GET("/js/*", echo.WrapHandler(fileServer))
+e.GET("/assets/*", echo.WrapHandler(fileServer))
 
 e.GET("/web", echo.WrapHandler(templ.Handler(web.HelloForm())))
 e.POST("/hello", echo.WrapHandler(http.HandlerFunc(web.HelloWebHandler)))

--- a/cmd/template/advanced/files/htmx/routes/fiber.tmpl
+++ b/cmd/template/advanced/files/htmx/routes/fiber.tmpl
@@ -1,4 +1,4 @@
-s.App.Static("/js", "./cmd/web/js")
+s.App.Static("/assets", "./cmd/web/assets")
 
 s.App.Get("/web", adaptor.HTTPHandler(templ.Handler(web.HelloForm())))
 

--- a/cmd/template/advanced/files/htmx/routes/gin.tmpl
+++ b/cmd/template/advanced/files/htmx/routes/gin.tmpl
@@ -1,4 +1,4 @@
-r.Static("/js", "./cmd/web/js")
+r.Static("/assets", "./cmd/web/assets")
 
 r.GET("/web", func(c *gin.Context) {
   templ.Handler(web.HelloForm()).ServeHTTP(c.Writer, c.Request)

--- a/cmd/template/advanced/files/htmx/routes/gorilla.tmpl
+++ b/cmd/template/advanced/files/htmx/routes/gorilla.tmpl
@@ -1,5 +1,5 @@
 fileServer := http.FileServer(http.FS(web.Files))
-r.PathPrefix("/js/").Handler(fileServer)
+r.PathPrefix("/assets/").Handler(fileServer)
 
 r.HandleFunc("/web", func(w http.ResponseWriter, r *http.Request) {
   templ.Handler(web.HelloForm()).ServeHTTP(w, r)

--- a/cmd/template/advanced/files/htmx/routes/http_router.tmpl
+++ b/cmd/template/advanced/files/htmx/routes/http_router.tmpl
@@ -1,5 +1,5 @@
   fileServer := http.FileServer(http.FS(web.Files))
-  r.Handler(http.MethodGet, "/js/*filepath", fileServer)
+  r.Handler(http.MethodGet, "/assets/*filepath", fileServer)
   r.Handler(http.MethodGet, "/web", templ.Handler(web.HelloForm()))
   r.HandlerFunc(http.MethodPost, "/hello", web.HelloWebHandler)
   

--- a/cmd/template/advanced/files/htmx/routes/standard_library.tmpl
+++ b/cmd/template/advanced/files/htmx/routes/standard_library.tmpl
@@ -1,4 +1,4 @@
   fileServer := http.FileServer(http.FS(web.Files))
-	mux.Handle("/js/", fileServer)
+	mux.Handle("/assets/", fileServer)
 	mux.Handle("/web", templ.Handler(web.HelloForm()))
 	mux.HandleFunc("/hello", web.HelloWebHandler)

--- a/docs/docs/advanced-flag/htmx-tmpl.md
+++ b/docs/docs/advanced-flag/htmx-tmpl.md
@@ -5,12 +5,14 @@ The WEB directory contains the web-related components and assets for the project
 ```
 web/
 │
-├── js/
-│   └── htmx.min.js         # htmx library for dynamic HTML content
+│
+├── assets/
+│   └── js/
+│       └── htmx.min.js     # htmx library for dynamic HTML content
 │
 ├── base.templ              # Base template for HTML structure
 ├── base_templ.go           # Generated Go code for base template
-├── efs.go                  # Embeds static files (e.g., JavaScript) into the Go binary
+├── efs.go                  # Embeds static files into the Go binary
 │
 ├── hello.go                # Handler for the Hello Web functionality
 ├── hello.templ             # Template for rendering the Hello form and post data

--- a/docs/docs/creating-project/air.md
+++ b/docs/docs/creating-project/air.md
@@ -20,7 +20,8 @@ watching .
 watching cmd
 watching cmd/api
 watching cmd/web
-watching cmd/web/js
+watching cmd/web/assets
+watching cmd/web/assets/js
 watching internal
 watching internal/database
 watching internal/server

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -27,37 +27,38 @@ Here's an overview of the project structure created by Go Blueprint when all opt
 / (Root)
 ├── .github/
 │   └── workflows/
-│       ├── go-test.yml     # GitHub Actions workflow for running tests.
-│       └── release.yml     # GitHub Actions workflow for releasing the application.
+│       ├── go-test.yml           # GitHub Actions workflow for running tests.
+│       └── release.yml           # GitHub Actions workflow for releasing the application.
 ├── cmd/
 │   ├── api/            
-│   │   └── main.go         # Main file for starting the server.
-│   └── web/             
-│       ├── js/         
-│       │   └── htmx.min.js # HTMX library for dynamic HTML content 
-│       ├── base.templ      # Base HTML template file.
-│       ├── base.templ.go   # Generated Go code for base template
-│       ├── efs.go          # File for handling file system operations.
-│       ├── hello.go        # Handler for serving "hello" endpoint.
-│       └── hello.templ     # Template file for the "hello" endpoint.
-|       └── hello.templ.go  # Generated Go code for the "hello" template. 
+│   │   └── main.go               # Main file for starting the server.
+│   └── web/
+│       ├── assets/               # Main file for starting the server.
+│       │   └── js/         
+│       │       └── htmx.min.js   # HTMX library for dynamic HTML content 
+│       ├── base.templ            # Base HTML template file.
+│       ├── base.templ.go         # Generated Go code for base template
+│       ├── efs.go                # File for handling file system operations.
+│       ├── hello.go              # Handler for serving "hello" endpoint.
+│       ├── hello.templ           # Template file for the "hello" endpoint.
+│       └── hello.templ.go        # Generated Go code for the "hello" template. 
 ├── internal/   
 │   ├── database/           
-│   │   └── database.go     # File containing functions related to database operations.
+│   │   └── database.go           # File containing functions related to database operations.
 │   └── server/             
-│       ├── routes.go       # File defining HTTP routes.
-│       └── server.go       # Main server logic.
+│       ├── routes.go             # File defining HTTP routes.
+│       └── server.go             # Main server logic.
 ├── tests/    
-│   └── handler_test.go     # Test file for testing HTTP handlers.
-├── .air.toml               # Configuration file for Air, a live-reload utility.
-├── docker-compose.yml      # Docker Compose configuration for defining DB config.
-├── .env                    # Environment configuration file.
-├── .gitignore              # File specifying which files and directories to ignore in Git.
-├── go.mod                  # Go module file for managing dependencies.
-├── .goreleaser.yml         # Configuration file for GoReleaser, a tool for building and releasing binaries.
-├── go.sum                  # Go module file containing checksums for dependencies.
-├── Makefile                # Makefile for defining and running commands.
-└── README.md               # Project's README file containing essential information about the project.
+│   └── handler_test.go           # Test file for testing HTTP handlers.
+├── .air.toml                     # Configuration file for Air, a live-reload utility.
+├── docker-compose.yml            # Docker Compose configuration for defining DB config.
+├── .env                          # Environment configuration file.
+├── .gitignore                    # File specifying which files and directories to ignore in Git.
+├── go.mod                        # Go module file for managing dependencies.
+├── .goreleaser.yml               # Configuration file for GoReleaser, a tool for building and releasing binaries.
+├── go.sum                        # Go module file containing checksums for dependencies.
+├── Makefile                      # Makefile for defining and running commands.
+└── README.md                     # Project's README file containing essential information about the project.
 ```
 
 This structure provides a comprehensive organization of your project, separating source code, tests, configurations and documentation.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Move `js/` into `assets/js` and make `assets/` as a static file server, so user can easily add a custom folder like `cmd/web/assets/css/` and link it into `base.templ` if they want it. 

## Description of Changes: 

- modify `cmd/program/program.go` to create assets/ 
- modify htmx src in `cmd/template/advanced/files/htmx/base.templ.tmpl`
- modify `go:embed "js"`  to `go:embed "assets"`
- modify frameworks static file routes in `cmd/template/advanced/files/htmx/routes`
- modify some file tree in docs

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
