### PR TITLE
Make use of pgx pool 

### DIFF
--- a/cmd/template/dbdriver/files/service/postgres.tmpl
+++ b/cmd/template/dbdriver/files/service/postgres.tmpl
@@ -36,10 +36,11 @@ func New() Service {
 		return dbInstance
 	}
 	connStr := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", username, password, host, port, database)
-	db, err := sql.Open("pgx", connStr)
+	pool, err := pgxpool.New(context.Background(), connStr)
 	if err != nil {
 		log.Fatal(err)
 	}
+db := stdlib.OpenDBFromPool(pool)
 	dbInstance = &service{
 		db: db,
 	}

--- a/cmd/template/dbdriver/files/service/postgres.tmpl
+++ b/cmd/template/dbdriver/files/service/postgres.tmpl
@@ -8,7 +8,8 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/joho/godotenv/autoload"
 )
 

--- a/cmd/template/dbdriver/files/service/postgres.tmpl
+++ b/cmd/template/dbdriver/files/service/postgres.tmpl
@@ -40,7 +40,7 @@ func New() Service {
 	if err != nil {
 		log.Fatal(err)
 	}
-db := stdlib.OpenDBFromPool(pool)
+	db := stdlib.OpenDBFromPool(pool)
 	dbInstance = &service{
 		db: db,
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

in the [https://github.com/jackc/pgx/wiki/Getting-started-with-pgx](https://github.com/jackc/pgx/wiki/Getting-started-with-pgx) they stated that using a pool of connection is better than using sql.Open and here I used a feature in the pgx stdlib which takes in a pool and returns a *sql.DB

## Description of Changes: 

- the database.New function now make use of a connection pool instead of sql.Open

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
