### PR TITLE
fix "Weboscket" typo

### DIFF
--- a/cmd/steps/steps.go
+++ b/cmd/steps/steps.go
@@ -105,7 +105,7 @@ func InitSteps(projectType flags.Framework, databaseType flags.Database) *Steps 
 					},
 					{
 						Flag:  "Websocket",
-						Title: "Weboscket endpoint",
+						Title: "Websocket endpoint",
 						Desc:  "Add a websocket endpoint",
 					},
 				},


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Just a small typo in the Websocket option.

## Description of Changes: 

- Change "Weboscket" to "Websocket".

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
