### PR TITLE
Enhance Health Function For Redis

### DIFF
--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"log"
 	"math"
@@ -42,9 +41,6 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
-		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
 	})
 
 	s := &service{db: rdb}

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -103,11 +104,11 @@ func (s *service) Health() map[string]string {
 	}
 
 	// Calculate the number of active connections.
-	activeConns := poolStats.TotalConns - poolStats.IdleConns
-	if activeConns < 0 {
-		activeConns = 0
-	}
-	stats["redis_active_connections"] = strconv.FormatUint(uint64(activeConns), 10)
+	// Note: We use math.Max to ensure that activeConns is always non-negative,
+	// avoiding the need for an explicit check for negative values.
+	// This prevents a potential underflow situation.
+	activeConns := uint64(math.Max(float64(poolStats.TotalConns-poolStats.IdleConns), 0))
+	stats["redis_active_connections"] = strconv.FormatUint(activeConns, 10)
 
 	// Calculate the pool size percentage.
 	poolSize := s.db.Options().PoolSize

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -42,7 +42,8 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
-		// Note: It's important to add this for a secure connection. Most cloud services that offer Redis should already have this configured in their services.
+		// Note: It's important to add this for a secure connection. Most cloud services that offer Redis should already have TLS configured in their services.
+		// So on the client-side, you only need to provide the necessary certificates without configuring TLS again (refer to the rule "Don't Repeat Yourself").
 		// For manual setup, please refer to the Redis documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -42,7 +42,7 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
-		// Note: It's important to add this for a secure connection. Most cloud services that offer Redis should already have this configured in their services.
+		// Note: It's important to add this for a secure connection. Most Redis cloud servers should already have this configured in their services.
 		// For manual setup, please refer to the Redis documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -42,7 +42,7 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
-		// Note: It's important to add this for a secure connection. Most Redis cloud servers should already have this configured in their services.
+		// Note: It's important to add this for a secure connection. Most cloud services that offer Redis should already have this configured in their services.
 		// For manual setup, please refer to the Redis documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -42,6 +42,8 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
+		// Note: It's important to add this for a secure connection. Most Redis cloud servers should already have this configured in their services.
+		// For manual setup, please refer to the Redis documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	_ "github.com/joho/godotenv/autoload"
@@ -50,21 +51,136 @@ func New() Service {
 	return s
 }
 
+// Health returns the health status and statistics of the Redis server.
 func (s *service) Health() map[string]string {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
+	// Ping the Redis server to check its availability.
 	result, err := s.db.Ping(ctx).Result()
 
 	if err != nil {
 		log.Fatalf(fmt.Sprintf("db down: %v", err))
 	}
 
-  if result != "PONG" {
-    log.Fatalf(fmt.Sprintf("Unexpected ping response: %s", result))
-  }
-
-	return map[string]string{
-		"message": "It's healthy",
+	// Check if the ping response is unexpected.
+	if result != "PONG" {
+		log.Fatalf(fmt.Sprintf("Unexpected ping response: %s", result))
 	}
+
+	// Retrieve Redis server information.
+	info, err := s.db.Info(ctx).Result()
+	if err != nil {
+		return map[string]string{
+			"redis_status":  "up",
+			"redis_message": fmt.Sprintf("Failed to retrieve Redis info: %v", err),
+		}
+	}
+
+	// Parse the Redis info response.
+	redisInfo := parseRedisInfo(info)
+
+	// Get the pool statistics of the Redis client.
+	poolStats := s.db.PoolStats()
+
+	// Prepare the stats map with Redis server information and pool statistics.
+	stats := map[string]string{
+		"redis_status":               "up",
+		"redis_message":              "It's healthy",
+		"redis_version":              redisInfo["redis_version"],
+		"redis_mode":                 redisInfo["redis_mode"],
+		"redis_connected_clients":    redisInfo["connected_clients"],
+		"redis_used_memory":          redisInfo["used_memory"],
+		"redis_used_memory_peak":     redisInfo["used_memory_peak"],
+		"redis_uptime_in_seconds":    redisInfo["uptime_in_seconds"],
+		"redis_hits_connections":     strconv.FormatUint(uint64(poolStats.Hits), 10),
+		"redis_misses_connections":   strconv.FormatUint(uint64(poolStats.Misses), 10),
+		"redis_timeouts_connections": strconv.FormatUint(uint64(poolStats.Timeouts), 10),
+		"redis_total_connections":    strconv.FormatUint(uint64(poolStats.TotalConns), 10),
+		"redis_idle_connections":     strconv.FormatUint(uint64(poolStats.IdleConns), 10),
+		"redis_stale_connections":    strconv.FormatUint(uint64(poolStats.StaleConns), 10),
+		"redis_max_memory":           redisInfo["maxmemory"],
+	}
+
+	// Calculate the number of active connections.
+	activeConns := poolStats.TotalConns - poolStats.IdleConns
+	if activeConns < 0 {
+		activeConns = 0
+	}
+	stats["redis_active_connections"] = strconv.FormatUint(uint64(activeConns), 10)
+
+	// Calculate the pool size percentage.
+	poolSize := s.db.Options().PoolSize
+	connectedClients, _ := strconv.Atoi(redisInfo["connected_clients"])
+	poolSizePercentage := float64(connectedClients) / float64(poolSize) * 100
+	stats["redis_pool_size_percentage"] = fmt.Sprintf("%.2f%%", poolSizePercentage)
+
+	// Evaluate Redis stats and update the stats map with relevant messages.
+	return s.evaluateRedisStats(redisInfo, stats)
+}
+
+// evaluateRedisStats evaluates the Redis server statistics and updates the stats map with relevant messages.
+func (s *service) evaluateRedisStats(redisInfo, stats map[string]string) map[string]string {
+	poolSize := s.db.Options().PoolSize
+	poolStats := s.db.PoolStats()
+	connectedClients, _ := strconv.Atoi(redisInfo["connected_clients"])
+	highConnectionThreshold := int(float64(poolSize) * 0.8)
+
+	// Check if the number of connected clients is high.
+	if connectedClients > highConnectionThreshold {
+		stats["redis_message"] = "Redis has a high number of connected clients"
+	}
+
+	// Check if the number of stale connections exceeds a threshold.
+	minStaleConnectionsThreshold := 500
+	if int(poolStats.StaleConns) > minStaleConnectionsThreshold {
+		stats["redis_message"] = fmt.Sprintf("Redis has %d stale connections.", poolStats.StaleConns)
+	}
+
+	// Check if Redis is using a significant amount of memory.
+	usedMemory, _ := strconv.ParseInt(redisInfo["used_memory"], 10, 64)
+	maxMemory, _ := strconv.ParseInt(redisInfo["maxmemory"], 10, 64)
+	if maxMemory > 0 {
+		usedMemoryPercentage := float64(usedMemory) / float64(maxMemory) * 100
+		if usedMemoryPercentage >= 90 {
+			stats["redis_message"] = "Redis is using a significant amount of memory"
+		}
+	}
+
+	// Check if Redis has been recently restarted.
+	uptimeInSeconds, _ := strconv.ParseInt(redisInfo["uptime_in_seconds"], 10, 64)
+	if uptimeInSeconds < 3600 {
+		stats["redis_message"] = "Redis has been recently restarted"
+	}
+
+	// Check if the number of idle connections is high.
+	idleConns := int(poolStats.IdleConns)
+	highIdleConnectionThreshold := int(float64(poolSize) * 0.7)
+	if idleConns > highIdleConnectionThreshold {
+		stats["redis_message"] = "Redis has a high number of idle connections"
+	}
+
+	// Check if the connection pool utilization is high.
+	poolUtilization := float64(poolStats.TotalConns-poolStats.IdleConns) / float64(poolSize) * 100
+	highPoolUtilizationThreshold := 90.0
+	if poolUtilization > highPoolUtilizationThreshold {
+		stats["redis_message"] = "Redis connection pool utilization is high"
+	}
+
+	return stats
+}
+
+// parseRedisInfo parses the Redis info response and returns a map of key-value pairs.
+func parseRedisInfo(info string) map[string]string {
+	result := make(map[string]string)
+	lines := strings.Split(info, "\r\n")
+	for _, line := range lines {
+		if strings.Contains(line, ":") {
+			parts := strings.Split(line, ":")
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			result[key] = value
+		}
+	}
+	return result
 }

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -2,7 +2,6 @@ package database
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"log"
 	"math"

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -41,6 +41,8 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
+		// Note: It's important to add this for a secure connection. Most cloud services that offer Redis should already have this configured in their services.
+		// For manual setup, please refer to the Redis documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
 		// TLSConfig: &tls.Config{
 		// 	MinVersion:   tls.VersionTLS12,
 		// },

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -42,9 +42,9 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
-		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
+		// TLSConfig: &tls.Config{
+		// 	MinVersion:   tls.VersionTLS12,
+		// },
 	})
 
 	s := &service{db: rdb}

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -54,7 +54,7 @@ func New() Service {
 
 // Health returns the health status and statistics of the Redis server.
 func (s *service) Health() map[string]string {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // Default is now 5s
 	defer cancel()
 
 	// Ping the Redis server to check its availability.

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -42,8 +42,7 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
-		// Note: It's important to add this for a secure connection. Most cloud services that offer Redis should already have TLS configured in their services.
-		// So on the client-side, you only need to provide the necessary certificates without configuring TLS again (refer to the rule "Don't Repeat Yourself").
+		// Note: It's important to add this for a secure connection. Most cloud services that offer Redis should already have this configured in their services.
 		// For manual setup, please refer to the Redis documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -57,31 +57,40 @@ func (s *service) Health() map[string]string {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // Default is now 5s
 	defer cancel()
 
-	// Ping the Redis server to check its availability.
-	result, err := s.db.Ping(ctx).Result()
+	stats := make(map[string]string)
 
+	// Check Redis health and populate the stats map
+	stats = s.checkRedisHealth(ctx, stats)
+
+	return stats
+}
+
+// checkRedisHealth checks the health of the Redis server and adds the relevant statistics to the stats map.
+func (s *service) checkRedisHealth(ctx context.Context, stats map[string]string) map[string]string {
+	// Ping the Redis server to check its availability.
+	pong, err := s.db.Ping(ctx).Result()
+	// Note: By extracting and simplifying like this, `log.Fatalf(fmt.Sprintf("db down: %v", err))` 
+	// can be changed into a normal error instead of a fatal error.
 	if err != nil {
 		log.Fatalf(fmt.Sprintf("db down: %v", err))
 	}
 
-	// Check if the ping response is unexpected.
-	if result != "PONG" {
-		log.Fatalf(fmt.Sprintf("Unexpected ping response: %s", result))
-	}
+	// Redis is up
+	stats["redis_status"] = "up"
+	stats["redis_message"] = "It's healthy"
+	stats["redis_ping_response"] = pong
 
 	// Retrieve Redis server information.
 	info, err := s.db.Info(ctx).Result()
 	if err != nil {
-		return map[string]string{
-			"redis_status":  "up",
-			"redis_message": fmt.Sprintf("Failed to retrieve Redis info: %v", err),
-		}
+		stats["redis_message"] = fmt.Sprintf("Failed to retrieve Redis info: %v", err)
+		return stats
 	}
 
 	// Parse the Redis info response.
 	redisInfo := parseRedisInfo(info)
 
-	// Get the pool statistics of the Redis client.
+	// Get the pool stats of the Redis client.
 	poolStats := s.db.PoolStats()
 
 	// Prepare the stats map with Redis server information and pool statistics.
@@ -90,23 +99,19 @@ func (s *service) Health() map[string]string {
 	// Using string types allows for easy conversion and compatibility with various data formats,
 	// making it convenient to create health stats for monitoring or other purposes.
 	// Also note that any raw "memory" (e.g., used_memory) value here is in bytes and can be converted to megabytes or gigabytes as a float64.
-	stats := map[string]string{
-		"redis_status":               "up",
-		"redis_message":              "It's healthy",
-		"redis_version":              redisInfo["redis_version"],
-		"redis_mode":                 redisInfo["redis_mode"],
-		"redis_connected_clients":    redisInfo["connected_clients"],
-		"redis_used_memory":          redisInfo["used_memory"],
-		"redis_used_memory_peak":     redisInfo["used_memory_peak"],
-		"redis_uptime_in_seconds":    redisInfo["uptime_in_seconds"],
-		"redis_hits_connections":     strconv.FormatUint(uint64(poolStats.Hits), 10),
-		"redis_misses_connections":   strconv.FormatUint(uint64(poolStats.Misses), 10),
-		"redis_timeouts_connections": strconv.FormatUint(uint64(poolStats.Timeouts), 10),
-		"redis_total_connections":    strconv.FormatUint(uint64(poolStats.TotalConns), 10),
-		"redis_idle_connections":     strconv.FormatUint(uint64(poolStats.IdleConns), 10),
-		"redis_stale_connections":    strconv.FormatUint(uint64(poolStats.StaleConns), 10),
-		"redis_max_memory":           redisInfo["maxmemory"],
-	}
+	stats["redis_version"] = redisInfo["redis_version"]
+	stats["redis_mode"] = redisInfo["redis_mode"]
+	stats["redis_connected_clients"] = redisInfo["connected_clients"]
+	stats["redis_used_memory"] = redisInfo["used_memory"]
+	stats["redis_used_memory_peak"] = redisInfo["used_memory_peak"]
+	stats["redis_uptime_in_seconds"] = redisInfo["uptime_in_seconds"]
+	stats["redis_hits_connections"] = strconv.FormatUint(uint64(poolStats.Hits), 10)
+	stats["redis_misses_connections"] = strconv.FormatUint(uint64(poolStats.Misses), 10)
+	stats["redis_timeouts_connections"] = strconv.FormatUint(uint64(poolStats.Timeouts), 10)
+	stats["redis_total_connections"] = strconv.FormatUint(uint64(poolStats.TotalConns), 10)
+	stats["redis_idle_connections"] = strconv.FormatUint(uint64(poolStats.IdleConns), 10)
+	stats["redis_stale_connections"] = strconv.FormatUint(uint64(poolStats.StaleConns), 10)
+	stats["redis_max_memory"] = redisInfo["maxmemory"]
 
 	// Calculate the number of active connections.
 	// Note: We use math.Max to ensure that activeConns is always non-negative,

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log"
 	"math"
@@ -41,6 +42,9 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
 	})
 
 	s := &service{db: rdb}

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -85,6 +85,11 @@ func (s *service) Health() map[string]string {
 	poolStats := s.db.PoolStats()
 
 	// Prepare the stats map with Redis server information and pool statistics.
+	// Note: The "stats" map in the code uses string keys and values,
+	// which is suitable for structuring and serializing the data for the frontend (e.g., JSON, XML, HTMX).
+	// Using string types allows for easy conversion and compatibility with various data formats,
+	// making it convenient to create health stats for monitoring or other purposes.
+	// Also note that any raw "memory" (e.g., used_memory) value here is in bytes and can be converted to megabytes or gigabytes as a float64.
 	stats := map[string]string{
 		"redis_status":               "up",
 		"redis_message":              "It's healthy",

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -42,8 +42,6 @@ func New() Service {
 		Addr:     fullAddress,
 		Password: password,
 		DB:       num,
-		// Note: It's important to add this for a secure connection. Most Redis cloud servers should already have this configured in their services.
-		// For manual setup, please refer to the Redis documentation: https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/
 		TLSConfig: &tls.Config{
 			MinVersion: tls.VersionTLS12,
 		},

--- a/cmd/template/dbdriver/files/service/redis.tmpl
+++ b/cmd/template/dbdriver/files/service/redis.tmpl
@@ -69,8 +69,8 @@ func (s *service) Health() map[string]string {
 func (s *service) checkRedisHealth(ctx context.Context, stats map[string]string) map[string]string {
 	// Ping the Redis server to check its availability.
 	pong, err := s.db.Ping(ctx).Result()
-	// Note: By extracting and simplifying like this, `log.Fatalf(fmt.Sprintf("db down: %v", err))` 
-	// can be changed into a normal error instead of a fatal error.
+	// Note: By extracting and simplifying like this, `log.Fatalf(fmt.Sprintf("db down: %v", err))`
+	// can be changed into a standard error instead of a fatal error.
 	if err != nil {
 		log.Fatalf(fmt.Sprintf("db down: %v", err))
 	}

--- a/cmd/template/docker/files/docker-compose/redis.tmpl
+++ b/cmd/template/docker/files/docker-compose/redis.tmpl
@@ -6,3 +6,17 @@ services:
     restart: always
     ports:
       - "${DB_PORT}:6379"
+    # Note: Don't forget to modify the "tls-port", "requirepass", and other relevant settings as needed. This is just a default example.
+    command: >
+      redis-server /usr/local/etc/redis/redis.conf
+      --tls-port 6379
+      --port 0
+      --tls-cert-file /usr/local/etc/redis/redis.crt
+      --tls-key-file /usr/local/etc/redis/redis.key
+      --tls-ca-cert-file /usr/local/etc/redis/ca.crt
+      --requirepass ${DB_PASSWORD} # You can customize this; it's just a default value
+    volumes:
+      - ./redis-conf/redis.conf:/usr/local/etc/redis/redis.conf
+      - ./redis-conf/redis.crt:/usr/local/etc/redis/redis.crt
+      - ./redis-conf/redis.key:/usr/local/etc/redis/redis.key
+      - ./redis-conf/ca.crt:/usr/local/etc/redis/ca.crt

--- a/cmd/template/docker/files/docker-compose/redis.tmpl
+++ b/cmd/template/docker/files/docker-compose/redis.tmpl
@@ -6,17 +6,3 @@ services:
     restart: always
     ports:
       - "${DB_PORT}:6379"
-    # Note: Don't forget to modify the "tls-port", "requirepass", and other relevant settings as needed. This is just a default example.
-    command: >
-      redis-server /usr/local/etc/redis/redis.conf
-      --tls-port 6379
-      --port 0
-      --tls-cert-file /usr/local/etc/redis/redis.crt
-      --tls-key-file /usr/local/etc/redis/redis.key
-      --tls-ca-cert-file /usr/local/etc/redis/ca.crt
-      --requirepass ${DB_PASSWORD} # You can customize this; it's just a default value
-    volumes:
-      - ./redis-conf/redis.conf:/usr/local/etc/redis/redis.conf
-      - ./redis-conf/redis.crt:/usr/local/etc/redis/redis.crt
-      - ./redis-conf/redis.key:/usr/local/etc/redis/redis.key
-      - ./redis-conf/ca.crt:/usr/local/etc/redis/ca.crt


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

This is related to the following:

- #230

> [!NOTE]
> Also note that this data is raw and must be structured, parsed, and converted basically cooking to make it look like this:

```json
{
  "redis_health": {
    "status": "up",
    "message": "Redis connection pool utilization is high",
    "stats": {
      "version": "7.0.15",
      "mode": "standalone",
      "connected_clients": "10",
      "memory": {
        "used": {
          "mb": "22.38",
          "gb": "0.02"
        },
        "peak": {
          "mb": "46.57",
          "gb": "0.05"
        },
        "free": {
          "mb": "1130.00",
          "gb": "1.10"
        },
        "percentage": "1.98%"
      },
      "uptime_stats": "6 days, 3 hours, 37 minutes, 20 seconds",
      "uptime": [
        {
          "day": "6"
        },
        {
          "hour": "3"
        },
        {
          "minute": "37"
        },
        {
          "second": "20"
        }
      ],
      "pooling": {
        "figures": {
          "hits": "10",
          "misses": "2",
          "timeouts": "0",
          "total": "4",
          "stale": "9",
          "idle": "5",
          "active": "0",
          "percentage": "62.50%"
        },
        "observed_total": "26"
      }
    }
  }
}
```
## Description of Changes: 

- [+] feat(redis.tmpl): implement comprehensive health check for Redis service
- [+] Add retrieval of Redis server information and pool statistics
- [+] Parse Redis info response and prepare stats map with relevant data
- [+] Evaluate Redis stats and update stats map with appropriate messages
- [+] Implement helper functions to parse Redis info and evaluate Redis stats
- [+] Check for high number of connected clients, stale connections, memory usage, recent restarts, idle connections, and pool utilization
- [+] Update health check response with detailed Redis status and statistics

## Checklist

- [X] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)
