### PR TITLE
Htmx-gh-action-fix

### DIFF
--- a/.github/workflows/update-htmx-version.yml
+++ b/.github/workflows/update-htmx-version.yml
@@ -10,19 +10,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Get version from file
         id: get_version_file
         run: |
-          VERSION_FILE=$(curl https://raw.githubusercontent.com/Melkeydev/go-blueprint/main/cmd/template/advanced/files/htmx/htmx.min.js.tmpl | grep version | awk -F'"' '{print "v" $2}')
+          VERSION_FILE=$(curl -s https://raw.githubusercontent.com/Melkeydev/go-blueprint/main/cmd/template/advanced/files/htmx/htmx.min.js.tmpl | grep version | awk -F'"' '{print "v" $2}')
           echo "version file: $VERSION_FILE"
-          echo "version_file=$VERSION_FILE" >> $GITHUB_OUTPUT
+          if [[ "$VERSION_FILE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version_file=$VERSION_FILE" >> $GITHUB_OUTPUT
+          else
+            echo "Invalid VERSION_FILE format: $VERSION_FILE" >&2
+            exit 1
+          fi
 
       - name: Get version from GitHub API
         id: get_version_api
         run: |
           VERSION_API=$(curl -s https://api.github.com/repos/bigskysoftware/htmx/releases/latest | jq -r '.tag_name')
           echo "version api: $VERSION_API"
-          echo "version_file=$VERSION_API" >> $GITHUB_OUTPUT
+          if [[ "$VERSION_API" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "version_api=$VERSION_API" >> $GITHUB_OUTPUT
+          else
+            echo "Invalid VERSION_API format: $VERSION_API" >&2
+            exit 1
+          fi
 
       - name: Compare versions
         id: compare_versions

--- a/.github/workflows/update-htmx-version.yml
+++ b/.github/workflows/update-htmx-version.yml
@@ -2,7 +2,8 @@ name: Check for new htmx release
 
 on:
   schedule:
-    - cron: '0 0 * * Sun'
+    # - cron: '0 0 * * Sun'
+    - cron: '*/5 * * * *'
 
 jobs:
   check_release:
@@ -14,17 +15,19 @@ jobs:
         run: |
           VERSION_FILE=$(curl https://raw.githubusercontent.com/Melkeydev/go-blueprint/main/cmd/template/advanced/files/htmx/htmx.min.js.tmpl | grep version | awk -F'"' '{print "v" $2}')
           echo "version file: $VERSION_FILE"
+          echo "::set-output name=version_file::$VERSION_FILE"
 
       - name: Get version from GitHub API
         id: get_version_api
         run: |
           VERSION_API=$(curl -s https://api.github.com/repos/bigskysoftware/htmx/releases/latest | jq -r '.tag_name')
           echo "version api: $VERSION_API"
+          echo "::set-output name=version_api::$VERSION_API"
 
       - name: Compare versions
         id: compare_versions
         run: |
-          if [ "$VERSION_API" != "$VERSION_FILE" ]; then
+          if [ "${{ steps.get_version_api.outputs.version_api }}" != "${{ steps.get_version_file.outputs.version_file }}" ]; then
             echo "release_changed=true" >> $GITHUB_OUTPUT
             echo "Release changed: true"
           else

--- a/.github/workflows/update-htmx-version.yml
+++ b/.github/workflows/update-htmx-version.yml
@@ -15,14 +15,14 @@ jobs:
         run: |
           VERSION_FILE=$(curl https://raw.githubusercontent.com/Melkeydev/go-blueprint/main/cmd/template/advanced/files/htmx/htmx.min.js.tmpl | grep version | awk -F'"' '{print "v" $2}')
           echo "version file: $VERSION_FILE"
-          echo "::set-output name=version_file::$VERSION_FILE"
+          echo "version_file=$VERSION_FILE" >> $GITHUB_OUTPUT
 
       - name: Get version from GitHub API
         id: get_version_api
         run: |
           VERSION_API=$(curl -s https://api.github.com/repos/bigskysoftware/htmx/releases/latest | jq -r '.tag_name')
           echo "version api: $VERSION_API"
-          echo "::set-output name=version_api::$VERSION_API"
+          echo "version_file=$VERSION_API" >> $GITHUB_OUTPUT
 
       - name: Compare versions
         id: compare_versions

--- a/.github/workflows/update-htmx-version.yml
+++ b/.github/workflows/update-htmx-version.yml
@@ -3,7 +3,7 @@ name: Check for new htmx release
 on:
   schedule:
     # - cron: '0 0 * * Sun'
-    - cron: '*/5 * * * *'
+    - cron: '*/5  * * * *'
 
 jobs:
   check_release:

--- a/.github/workflows/update-htmx-version.yml
+++ b/.github/workflows/update-htmx-version.yml
@@ -2,8 +2,7 @@ name: Check for new htmx release
 
 on:
   schedule:
-    # - cron: '0 0 * * Sun'
-    - cron: '*/5  * * * *'
+    - cron: '0 0 * * Sun'
 
 jobs:
   check_release:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Previous workflow didn't work as expected. It was pretty hard to test it. Now, when the new HTMX is out, the issue was identified and fixed.

should open a new PR when there is a change in the HTMX version.

Logs from work that was failing for future reference:
```bash
Run VERSION_FILE=$(curl https://raw.githubusercontent.com/Melkeydev/go-blueprint/main/cmd/template/advanced/files/htmx/htmx.min.js.tmpl | grep version | awk -F'"' '{print "v" $2}')
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  106k  100  106k    0     0   42[5](https://github.com/Melkeydev/go-blueprint/actions/runs/9047371052/job/24859234016#step:3:6)k      0 --:--:-- --:--:-- --:--:--  426k
version file: v1.9.11

------------------------------------------

Run VERSION_API=$(curl -s https://api.github.com/repos/bigskysoftware/htmx/releases/latest | jq -r '.tag_name')
version api: v1.9.12

---------------------------------------------
Run if [ "$VERSION_API" != "$VERSION_FILE" ]; then
  if [ "$VERSION_API" != "$VERSION_FILE" ]; then
    echo "release_changed=true" >> $GITHUB_OUTPUT
    echo "Release changed: true"
  else
    echo "release_changed=false" >> $GITHUB_OUTPUT
    echo "Release changed: false"
  fi
  shell: /usr/bin/bash -e {0}
Release changed: false
```
Related issue ticket #198 