### PR TITLE
Adding templ check in the make file

### DIFF
--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -4,70 +4,68 @@
 all: build
 
 build:
-    @echo "Building..."
-    {{if .AdvancedOptions.htmx}}
-         @if command -v templ > /dev/null; then \
-             @templ generate; \
-         else \
-             read -p "Go's 'templ' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
-             if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-                 go install github.com/a-h/templ/cmd/templ@latest; \
-                 @templ generate; \
-             else \
-                 echo "You chose not to install templ. Exiting..."; \
-                 exit 1; \
-             fi; \
-         fi
-    {{end}}
-    @go build -o main cmd/api/main.go
+	@echo "Building..."
+	{{if .AdvancedOptions.htmx}}@if command -v templ > /dev/null; then \
+		templ generate; \
+	else \
+		read -p "Go's 'templ' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
+		if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
+			go install github.com/a-h/templ/cmd/templ@latest; \
+			templ generate; \
+		else \
+			echo "You chose not to install templ. Exiting..."; \
+			exit 1; \
+		fi; \
+	fi{{end}}
+	@go build -o main cmd/api/main.go
 
 # Run the application
 run:
-    @go run cmd/api/main.go
+	@go run cmd/api/main.go
 
 # Create DB container
 docker-run:
-    @if docker compose up 2>/dev/null; then \
-        : ; \
-    else \
-        echo "Falling back to Docker Compose V1"; \
-        docker-compose up; \
-    fi
+	@if docker compose up 2>/dev/null; then \
+		: ; \
+	else \
+		echo "Falling back to Docker Compose V1"; \
+		docker-compose up; \
+	fi
 
 # Shutdown DB container
 docker-down:
-    @if docker compose down 2>/dev/null; then \
-        : ; \
-    else \
-        echo "Falling back to Docker Compose V1"; \
-        docker-compose down; \
-    fi
+	@if docker compose down 2>/dev/null; then \
+		: ; \
+	else \
+		echo "Falling back to Docker Compose V1"; \
+		docker-compose down; \
+	fi
 
 # Test the application
 test:
-    @echo "Testing..."
-    @go test ./tests -v
+	@echo "Testing..."
+	@go test ./tests -v
 
 # Clean the binary
 clean:
-    @echo "Cleaning..."
-    @rm -f main
+	@echo "Cleaning..."
+	@rm -f main
 
 # Live Reload
 watch:
-    @if command -v air > /dev/null; then \
-        air; \
-        echo "Watching...";\
-    else \
-        read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
-        if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-            go install github.com/cosmtrek/air@latest; \
-            air; \
-            echo "Watching...";\
-        else \
-            echo "You chose not to install air. Exiting..."; \
-            exit 1; \
-        fi; \
-    fi
+	@if command -v air > /dev/null; then \
+		air; \
+		echo "Watching...";\
+	else \
+		read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
+		if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
+			go install github.com/cosmtrek/air@latest; \
+			air; \
+			echo "Watching...";\
+		else \
+			echo "You chose not to install air. Exiting..."; \
+			exit 1; \
+		fi; \
+	fi
 
 .PHONY: all build run test clean

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -4,57 +4,70 @@
 all: build
 
 build:
-	@echo "Building..."
-	{{if .AdvancedOptions.htmx}}@templ generate{{end}}
-	@go build -o main cmd/api/main.go
+    @echo "Building..."
+    {{if .AdvancedOptions.htmx}}
+         @if command -v templ > /dev/null; then \
+             @templ generate; \
+         else \
+             read -p "Go's 'templ' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
+             if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
+                 go install github.com/a-h/templ/cmd/templ@latest; \
+                 @templ generate; \
+             else \
+                 echo "You chose not to install templ. Exiting..."; \
+                 exit 1; \
+             fi; \
+         fi
+    {{end}}
+    @go build -o main cmd/api/main.go
 
 # Run the application
 run:
-	@go run cmd/api/main.go
+    @go run cmd/api/main.go
 
 # Create DB container
 docker-run:
-	@if docker compose up 2>/dev/null; then \
-		: ; \
-	else \
-		echo "Falling back to Docker Compose V1"; \
-		docker-compose up; \
-	fi
+    @if docker compose up 2>/dev/null; then \
+        : ; \
+    else \
+        echo "Falling back to Docker Compose V1"; \
+        docker-compose up; \
+    fi
 
 # Shutdown DB container
 docker-down:
-	@if docker compose down 2>/dev/null; then \
-		: ; \
-	else \
-		echo "Falling back to Docker Compose V1"; \
-		docker-compose down; \
-	fi
+    @if docker compose down 2>/dev/null; then \
+        : ; \
+    else \
+        echo "Falling back to Docker Compose V1"; \
+        docker-compose down; \
+    fi
 
 # Test the application
 test:
-	@echo "Testing..."
-	@go test ./tests -v
+    @echo "Testing..."
+    @go test ./tests -v
 
 # Clean the binary
 clean:
-	@echo "Cleaning..."
-	@rm -f main
+    @echo "Cleaning..."
+    @rm -f main
 
 # Live Reload
 watch:
-	@if command -v air > /dev/null; then \
-	    air; \
-	    echo "Watching...";\
-	else \
-	    read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
-	    if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-	        go install github.com/cosmtrek/air@latest; \
-	        air; \
-	        echo "Watching...";\
-	    else \
-	        echo "You chose not to install air. Exiting..."; \
-	        exit 1; \
-	    fi; \
-	fi
+    @if command -v air > /dev/null; then \
+        air; \
+        echo "Watching...";\
+    else \
+        read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
+        if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
+            go install github.com/cosmtrek/air@latest; \
+            air; \
+            echo "Watching...";\
+        else \
+            echo "You chose not to install air. Exiting..."; \
+            exit 1; \
+        fi; \
+    fi
 
 .PHONY: all build run test clean


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Under the Makefile there were no checks to see if templ was installed or not.

## Description of Changes: 

- I copied air's checks and changed to fit templ
- I removed the `@` cause make was unable to find the `templ` command

## Checklist

- [X] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
