### PR TITLE
feat: added db schema to postgres template

### DIFF
--- a/cmd/template/dbdriver/files/env/postgres.tmpl
+++ b/cmd/template/dbdriver/files/env/postgres.tmpl
@@ -3,3 +3,4 @@ DB_PORT=5432
 DB_DATABASE=blueprint
 DB_USERNAME=melkey
 DB_PASSWORD=password1234
+DB_SCHEMA=public

--- a/cmd/template/dbdriver/files/service/postgres.tmpl
+++ b/cmd/template/dbdriver/files/service/postgres.tmpl
@@ -34,6 +34,7 @@ var (
 	username = os.Getenv("DB_USERNAME")
 	port     = os.Getenv("DB_PORT")
 	host     = os.Getenv("DB_HOST")
+  schema   = os.Getenv("DB_SCHEMA")
 	dbInstance *service
 )
 
@@ -42,7 +43,7 @@ func New() Service {
 	if dbInstance != nil {
 		return dbInstance
 	}
-	connStr := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable", username, password, host, port, database)
+	connStr := fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable&search_path=%s", username, password, host, port, database, schema)
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/template/dbdriver/files/service/postgres.tmpl
+++ b/cmd/template/dbdriver/files/service/postgres.tmpl
@@ -34,7 +34,7 @@ var (
 	username = os.Getenv("DB_USERNAME")
 	port     = os.Getenv("DB_PORT")
 	host     = os.Getenv("DB_HOST")
-  schema   = os.Getenv("DB_SCHEMA")
+        schema   = os.Getenv("DB_SCHEMA")
 	dbInstance *service
 )
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The current postgres service didn't accept schema and used public by default. Added support for specifying schema through envs

## Description of Changes: 

- added DB_SCHEMA env to postgres template
- passed search_path in dsn 

## Checklist

- [*] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)

