### PR TITLE
Add flake for Nix users

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  lib,
+}: let
+  go-blueprint = pkgs.buildGoModule {
+    pname = "go-blueprint";
+    version = "0.5.14";
+    src = ./.;
+
+    # Needs to be updated each time dependencies change
+    # Use lib.fakeHash and run 'nix build .#' to obtain the new hash
+    # vendorHash = lib.fakeHash; # uncomment this and comment the definition below out to obtain the new hash
+    vendorHash = "sha256-WBzToupC1/O70OYHbKk7S73OEe7XRLAAbY5NoLL7xvw=";
+
+    meta = with lib; {
+      description = "The ultimate golang blueprint library";
+      homepage = "https://github.com/Melkeydev/go-blueprint";
+      licence = licenses.mit;
+    };
+  };
+in
+  # Output a shell script that runs go-blueprint with go as a runtime dependency
+  pkgs.writeShellApplication {
+    name = "go-blueprint";
+    runtimeInputs = with pkgs; [go];
+    text = ''
+      "${go-blueprint}/bin/go-blueprint" "$@"
+    '';
+  }

--- a/default.nix
+++ b/default.nix
@@ -3,8 +3,7 @@
   lib,
 }: let
   go-blueprint = pkgs.buildGoModule {
-    pname = "go-blueprint";
-    version = "0.5.14";
+    name = "go-blueprint";
     src = ./.;
 
     # Needs to be updated each time dependencies change

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,317 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717408969,
+        "narHash": "sha256-Q0OEFqe35fZbbRPPRdrjTUUChKVhhWXz3T9ZSKmaoVY=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "1ebbe68d57457c8cae98145410b164b5477761f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixvim",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717664902,
+        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixvim",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717525419,
+        "narHash": "sha256-5z2422pzWnPXHgq2ms8lcCfttM0dz+hg+x1pCcNkAws=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "a7117efb3725e6197dd95424136f79147aa35e5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716993688,
+        "narHash": "sha256-vo5k2wQekfeoq/2aleQkBN41dQiQHNTniZeVONWiWLs=",
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "rev": "c0d5b8c54d6828516c97f6be9f2d00c63a363df4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "lnl7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "path": "/nix/store/qgbn0imyridkb9527v6gnv6z3jzzprb9-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1717196966,
+        "narHash": "sha256-yZKhxVIKd2lsbOqYd5iDoUIwsRZFqE87smE2Vzf6Ck0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixvim": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
+        "home-manager": "home-manager",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs_2",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1717681257,
+        "narHash": "sha256-0PhFvfc4wDjba1cus2ALsfn0wVizeKkcuF+aqvDJivg=",
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "rev": "36f2e51b28ee3389a67ed5e9ed5c4bd388b06918",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixvim": "nixvim"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixvim",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717278143,
+        "narHash": "sha256-u10aDdYrpiGOLoxzY/mJ9llST9yO8Q7K/UlROoNxzDw=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "3eb96ca1ae9edf792a8e0963cc92fddfa5a87706",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,28 +15,7 @@
       pkgs = import nixpkgs {inherit system;};
     in {
       packages = {
-        default = let
-          module = pkgs.buildGoModule {
-            name = "go-blueprint";
-
-            src = ./.;
-
-            vendorHash = "sha256-WBzToupC1/O70OYHbKk7S73OEe7XRLAAbY5NoLL7xvw=";
-
-            meta = with pkgs.lib; {
-              description = "Go-blueprint allows users to spin up a quick Go project using a popular framework";
-              homepage = "https://github.com/Melkeydev/go-blueprint";
-              licence = licenses.mit;
-            };
-          };
-        in
-          pkgs.symlinkJoin rec {
-            name = "go-blueprint";
-            # Go needed in PATH to generate go.mod
-            paths = [module] ++ [pkgs.go];
-            buildInputs = [pkgs.makeWrapper];
-            postBuild = "wrapProgram $out/bin/${name} --prefix PATH : $out/bin";
-          };
+        default = pkgs.callPackage ./default.nix {};
       };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -18,16 +18,8 @@
         default = let
           module = pkgs.buildGoModule {
             name = "go-blueprint";
-            # version = "0.5.14";
 
             src = ./.;
-
-            # src = pkgs.fetchFromGitHub {
-            #   owner = "Melkeydev";
-            #   repo = "go-blueprint";
-            #   rev = "v${version}";
-            #   hash = "sha256-vQ7LXC70MpqdHxR4JpM5iRQ4mTO0MVtZF94G/f8sR6A=";
-            # };
 
             vendorHash = "sha256-WBzToupC1/O70OYHbKk7S73OEe7XRLAAbY5NoLL7xvw=";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,6 @@
 {
+  description = "Go-blueprint allows users to spin up a quick Go project using a popular framework";
+
   inputs = {
     nixvim.url = "github:nix-community/nixvim";
     flake-utils.url = "github:numtide/flake-utils";
@@ -28,7 +30,7 @@
             vendorHash = "sha256-WBzToupC1/O70OYHbKk7S73OEe7XRLAAbY5NoLL7xvw=";
 
             meta = with pkgs.lib; {
-              description = "The ultimate golang blueprint library";
+              description = "Go-blueprint allows users to spin up a quick Go project using a popular framework";
               homepage = "https://github.com/Melkeydev/go-blueprint";
               licence = licenses.mit;
             };

--- a/flake.nix
+++ b/flake.nix
@@ -16,16 +16,18 @@
     in {
       packages = {
         default = let
-          module = pkgs.buildGoModule rec {
-            pname = "go-blueprint";
-            version = "0.5.14";
+          module = pkgs.buildGoModule {
+            name = "go-blueprint";
+            # version = "0.5.14";
 
-            src = pkgs.fetchFromGitHub {
-              owner = "Melkeydev";
-              repo = "go-blueprint";
-              rev = "v${version}";
-              hash = "sha256-vQ7LXC70MpqdHxR4JpM5iRQ4mTO0MVtZF94G/f8sR6A=";
-            };
+            src = ./.;
+
+            # src = pkgs.fetchFromGitHub {
+            #   owner = "Melkeydev";
+            #   repo = "go-blueprint";
+            #   rev = "v${version}";
+            #   hash = "sha256-vQ7LXC70MpqdHxR4JpM5iRQ4mTO0MVtZF94G/f8sR6A=";
+            # };
 
             vendorHash = "sha256-WBzToupC1/O70OYHbKk7S73OEe7XRLAAbY5NoLL7xvw=";
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  inputs = {
+    nixvim.url = "github:nix-community/nixvim";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+    in {
+      packages = {
+        default = let
+          module = pkgs.buildGoModule rec {
+            pname = "go-blueprint";
+            version = "0.5.14";
+
+            src = pkgs.fetchFromGitHub {
+              owner = "Melkeydev";
+              repo = "go-blueprint";
+              rev = "v${version}";
+              hash = "sha256-vQ7LXC70MpqdHxR4JpM5iRQ4mTO0MVtZF94G/f8sR6A=";
+            };
+
+            vendorHash = "sha256-WBzToupC1/O70OYHbKk7S73OEe7XRLAAbY5NoLL7xvw=";
+
+            meta = with pkgs.lib; {
+              description = "The ultimate golang blueprint library";
+              homepage = "https://github.com/Melkeydev/go-blueprint";
+              licence = licenses.mit;
+            };
+          };
+        in
+          pkgs.symlinkJoin rec {
+            name = "go-blueprint";
+            # Go needed in PATH to generate go.mod
+            paths = [module] ++ [pkgs.go];
+            buildInputs = [pkgs.makeWrapper];
+            postBuild = "wrapProgram $out/bin/${name} --prefix PATH : $out/bin";
+          };
+      };
+    });
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Flakes are a Nix solution that allow for reproducible package builds, development environments, and more. This flake would allow Nix users to use go-blueprint in a way that better interfaced with the rest of their system. 

## Description of Changes: 

- Create flake.nix file and include a package that can be used by Nix users to run go-blueprint or add it to their system

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (if applicable)

