### PR TITLE
added middleware code to all frameworks

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -65,6 +65,7 @@ type Docker struct {
 type Templater interface {
 	Main() []byte
 	Server() []byte
+	Middleware() []byte
 	Routes() []byte
 	TestHandler() []byte
 	HtmxTemplRoutes() []byte
@@ -543,6 +544,12 @@ func (p *Project) CreateMainFile() error {
 		cobra.CheckErr(err)
 		return err
 	}
+	err = p.CreateFileWithInjection(internalServerPath, projectPath, "middleware.go", "middleware")
+	if err != nil {
+		log.Printf("Error injecting middleware.go file: %v", err)
+		cobra.CheckErr(err)
+		return err
+	}
 
 	err = p.CreateFileWithInjection(root, projectPath, ".env", "env")
 	if err != nil {
@@ -648,6 +655,9 @@ func (p *Project) CreateFileWithInjection(pathToCreate string, projectPath strin
 		err = createdTemplate.Execute(createdFile, p)
 	case "server":
 		createdTemplate := template.Must(template.New(fileName).Parse(string(p.FrameworkMap[p.ProjectType].templater.Server())))
+		err = createdTemplate.Execute(createdFile, p)
+	case "middleware":
+		createdTemplate := template.Must(template.New(fileName).Parse(string(p.FrameworkMap[p.ProjectType].templater.Middleware())))
 		err = createdTemplate.Execute(createdFile, p)
 	case "routes":
 		routeFileBytes := p.FrameworkMap[p.ProjectType].templater.Routes()

--- a/cmd/template/framework/chiRoutes.go
+++ b/cmd/template/framework/chiRoutes.go
@@ -24,6 +24,10 @@ func (c ChiTemplates) Server() []byte {
 	return standardServerTemplate
 }
 
+func (c ChiTemplates) Middleware() []byte {
+	return standardMiddlewareTemplate
+}
+
 func (c ChiTemplates) Routes() []byte {
 	return chiRoutesTemplate
 }

--- a/cmd/template/framework/echoRoutes.go
+++ b/cmd/template/framework/echoRoutes.go
@@ -9,6 +9,9 @@ import (
 //go:embed files/routes/echo.go.tmpl
 var echoRoutesTemplate []byte
 
+//go:embed files/middleware/echo.go.tmpl
+var echoMiddlewareTemplate []byte
+
 //go:embed files/tests/echo-test.go.tmpl
 var echoTestHandlerTemplate []byte
 
@@ -19,8 +22,13 @@ type EchoTemplates struct{}
 func (e EchoTemplates) Main() []byte {
 	return mainTemplate
 }
+
 func (e EchoTemplates) Server() []byte {
 	return standardServerTemplate
+}
+
+func (e EchoTemplates) Middleware() []byte {
+	return echoMiddlewareTemplate
 }
 
 func (e EchoTemplates) Routes() []byte {

--- a/cmd/template/framework/fiberServer.go
+++ b/cmd/template/framework/fiberServer.go
@@ -12,6 +12,9 @@ var fiberRoutesTemplate []byte
 //go:embed files/server/fiber.go.tmpl
 var fiberServerTemplate []byte
 
+//go:embed files/middleware/fiber.go.tmpl
+var fiberMiddlewareTemplate []byte
+
 //go:embed files/main/fiber_main.go.tmpl
 var fiberMainTemplate []byte
 
@@ -25,8 +28,13 @@ type FiberTemplates struct{}
 func (f FiberTemplates) Main() []byte {
 	return fiberMainTemplate
 }
+
 func (f FiberTemplates) Server() []byte {
 	return fiberServerTemplate
+}
+
+func (f FiberTemplates) Middleware() []byte {
+	return fiberMiddlewareTemplate
 }
 
 func (f FiberTemplates) Routes() []byte {

--- a/cmd/template/framework/files/middleware/echo.go.tmpl
+++ b/cmd/template/framework/files/middleware/echo.go.tmpl
@@ -1,0 +1,12 @@
+package server
+
+import (
+	"github.com/labstack/echo/v4"
+)
+
+func DummyMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Response().Header().Set(echo.HeaderServer, "Echo!")
+		return next(c)
+	}
+}

--- a/cmd/template/framework/files/middleware/echo.go.tmpl
+++ b/cmd/template/framework/files/middleware/echo.go.tmpl
@@ -1,12 +1,14 @@
 package server
 
 import (
+	"log/slog"
+
 	"github.com/labstack/echo/v4"
 )
 
-func DummyMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+func Logger(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		c.Response().Header().Set(echo.HeaderServer, "Echo!")
+		slog.Info("Request URL path", "path", c.Request().URL.Path)
 		return next(c)
 	}
 }

--- a/cmd/template/framework/files/middleware/fiber.go.tmpl
+++ b/cmd/template/framework/files/middleware/fiber.go.tmpl
@@ -1,0 +1,13 @@
+package server
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func DummyMiddleware(c *fiber.Ctx) error {
+	// Set a custom header on all responses:
+	c.Set("X-Custom-Header", "Hello, World")
+
+	// Go to next middleware:
+	return c.Next()
+}

--- a/cmd/template/framework/files/middleware/fiber.go.tmpl
+++ b/cmd/template/framework/files/middleware/fiber.go.tmpl
@@ -1,13 +1,12 @@
 package server
 
 import (
+	"log/slog"
+
 	"github.com/gofiber/fiber/v2"
 )
 
-func DummyMiddleware(c *fiber.Ctx) error {
-	// Set a custom header on all responses:
-	c.Set("X-Custom-Header", "Hello, World")
-
-	// Go to next middleware:
+func Logger(c *fiber.Ctx) error {
+	slog.Info("Request URL path", "path", c.Request().URI().Path())
 	return c.Next()
 }

--- a/cmd/template/framework/files/middleware/gin.go.tmpl
+++ b/cmd/template/framework/files/middleware/gin.go.tmpl
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"log"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func DummyMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		t := time.Now()
+
+		// Set example variable
+		c.Set("example", "12345")
+
+		// before request
+
+		c.Next()
+
+		// after request
+		latency := time.Since(t)
+		log.Print(latency)
+
+		// access the status we are sending
+		status := c.Writer.Status()
+		log.Println(status)
+	}
+}

--- a/cmd/template/framework/files/middleware/gin.go.tmpl
+++ b/cmd/template/framework/files/middleware/gin.go.tmpl
@@ -1,29 +1,14 @@
 package server
 
 import (
-	"log"
-	"time"
+	"log/slog"
 
 	"github.com/gin-gonic/gin"
 )
 
-func DummyMiddleware() gin.HandlerFunc {
+func Logger() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		t := time.Now()
-
-		// Set example variable
-		c.Set("example", "12345")
-
-		// before request
-
+		slog.Info("Request URL path", "path", c.Request.RequestURI)
 		c.Next()
-
-		// after request
-		latency := time.Since(t)
-		log.Print(latency)
-
-		// access the status we are sending
-		status := c.Writer.Status()
-		log.Println(status)
 	}
 }

--- a/cmd/template/framework/files/middleware/gorilla.go.tmpl
+++ b/cmd/template/framework/files/middleware/gorilla.go.tmpl
@@ -1,15 +1,13 @@
 package server
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 )
 
-func DummyMiddleware(next http.Handler) http.Handler {
+func Logger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Do stuff here
-		log.Println(r.RequestURI)
-		// Call the next handler, which can be another middleware in the chain, or the final handler.
+		slog.Info("Request URL path", "path", r.RequestURI)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/cmd/template/framework/files/middleware/gorilla.go.tmpl
+++ b/cmd/template/framework/files/middleware/gorilla.go.tmpl
@@ -1,0 +1,15 @@
+package server
+
+import (
+	"log"
+	"net/http"
+)
+
+func DummyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Do stuff here
+		log.Println(r.RequestURI)
+		// Call the next handler, which can be another middleware in the chain, or the final handler.
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/template/framework/files/middleware/http_router.go.tmpl
+++ b/cmd/template/framework/files/middleware/http_router.go.tmpl
@@ -1,0 +1,12 @@
+package server
+
+import (
+	"net/http"
+)
+
+func DummyMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Do stuff here
+		next(w, r)
+	})
+}

--- a/cmd/template/framework/files/middleware/http_router.go.tmpl
+++ b/cmd/template/framework/files/middleware/http_router.go.tmpl
@@ -1,12 +1,13 @@
 package server
 
 import (
+	"log/slog"
 	"net/http"
 )
 
-func DummyMiddleware(next http.HandlerFunc) http.HandlerFunc {
+func Logger(next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Do stuff here
+		slog.Info("Request URL path", "path", r.RequestURI)
 		next(w, r)
 	})
 }

--- a/cmd/template/framework/files/middleware/standard_library.go.tmpl
+++ b/cmd/template/framework/files/middleware/standard_library.go.tmpl
@@ -1,0 +1,21 @@
+package server
+
+import "net/http"
+
+type Middleware func(http.Handler) http.Handler
+
+func MiddlewareStack(ms ...Middleware) Middleware {
+	return func(next http.Handler) http.Handler {
+		for i := len(ms) - 1; i >= 0; i-- {
+			next = ms[i](next)
+		}
+		return next
+	}
+}
+
+func DummyMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Do stuff here
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/template/framework/files/middleware/standard_library.go.tmpl
+++ b/cmd/template/framework/files/middleware/standard_library.go.tmpl
@@ -1,6 +1,9 @@
 package server
 
-import "net/http"
+import (
+	"log/slog"
+	"net/http"
+)
 
 type Middleware func(http.Handler) http.Handler
 
@@ -13,9 +16,9 @@ func MiddlewareStack(ms ...Middleware) Middleware {
 	}
 }
 
-func DummyMiddleware(next http.Handler) http.Handler {
+func Logger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Do stuff here
+		slog.Info("Request URL path", "path", r.RequestURI)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/cmd/template/framework/files/routes/chi.go.tmpl
+++ b/cmd/template/framework/files/routes/chi.go.tmpl
@@ -17,7 +17,7 @@ import (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	r := chi.NewRouter()
-	r.Use(middleware.Logger, DummyMiddleware)
+	r.Use(middleware.Logger, Logger)
 
 	r.Get("/", s.HelloWorldHandler)
   {{if ne .DBDriver "none"}}

--- a/cmd/template/framework/files/routes/chi.go.tmpl
+++ b/cmd/template/framework/files/routes/chi.go.tmpl
@@ -17,7 +17,7 @@ import (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	r := chi.NewRouter()
-	r.Use(middleware.Logger)
+	r.Use(middleware.Logger, DummyMiddleware)
 
 	r.Get("/", s.HelloWorldHandler)
   {{if ne .DBDriver "none"}}

--- a/cmd/template/framework/files/routes/echo.go.tmpl
+++ b/cmd/template/framework/files/routes/echo.go.tmpl
@@ -14,9 +14,8 @@ import (
 )
 func (s *Server) RegisterRoutes() http.Handler {
 	e := echo.New()
-	e.Use(middleware.Logger())
+	e.Use(Logger)
 	e.Use(middleware.Recover())
-	e.Use(DummyMiddleware)
   {{.AdvancedTemplates.TemplateRoutes}}
 
 	e.GET("/", s.HelloWorldHandler)

--- a/cmd/template/framework/files/routes/echo.go.tmpl
+++ b/cmd/template/framework/files/routes/echo.go.tmpl
@@ -16,6 +16,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 	e := echo.New()
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
+	e.Use(DummyMiddleware)
   {{.AdvancedTemplates.TemplateRoutes}}
 
 	e.GET("/", s.HelloWorldHandler)

--- a/cmd/template/framework/files/routes/fiber.go.tmpl
+++ b/cmd/template/framework/files/routes/fiber.go.tmpl
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *FiberServer) RegisterFiberRoutes() {
-	s.App.Use(DummyMiddleware)
+	s.App.Use(Logger)
 	s.App.Get("/", s.HelloWorldHandler)
   {{if ne .DBDriver "none"}}
 	s.App.Get("/health", s.healthHandler)

--- a/cmd/template/framework/files/routes/fiber.go.tmpl
+++ b/cmd/template/framework/files/routes/fiber.go.tmpl
@@ -12,6 +12,7 @@ import (
 )
 
 func (s *FiberServer) RegisterFiberRoutes() {
+	s.App.Use(DummyMiddleware)
 	s.App.Get("/", s.HelloWorldHandler)
   {{if ne .DBDriver "none"}}
 	s.App.Get("/health", s.healthHandler)

--- a/cmd/template/framework/files/routes/gin.go.tmpl
+++ b/cmd/template/framework/files/routes/gin.go.tmpl
@@ -15,6 +15,8 @@ import (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	r := gin.Default()
+	
+	r.Use(DummyMiddleware())
 
 	r.GET("/", s.HelloWorldHandler)
   {{if ne .DBDriver "none"}}

--- a/cmd/template/framework/files/routes/gin.go.tmpl
+++ b/cmd/template/framework/files/routes/gin.go.tmpl
@@ -16,7 +16,7 @@ import (
 func (s *Server) RegisterRoutes() http.Handler {
 	r := gin.Default()
 	
-	r.Use(DummyMiddleware())
+	r.Use(Logger())
 
 	r.GET("/", s.HelloWorldHandler)
   {{if ne .DBDriver "none"}}

--- a/cmd/template/framework/files/routes/gorilla.go.tmpl
+++ b/cmd/template/framework/files/routes/gorilla.go.tmpl
@@ -15,7 +15,7 @@ import (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	r := mux.NewRouter()
-	r.Use(DummyMiddleware)
+	r.Use(Logger)
 	r.HandleFunc("/", s.HelloWorldHandler)
   {{if ne .DBDriver "none"}}
 	r.HandleFunc("/health", s.healthHandler)

--- a/cmd/template/framework/files/routes/gorilla.go.tmpl
+++ b/cmd/template/framework/files/routes/gorilla.go.tmpl
@@ -15,7 +15,7 @@ import (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	r := mux.NewRouter()
-
+	r.Use(DummyMiddleware)
 	r.HandleFunc("/", s.HelloWorldHandler)
   {{if ne .DBDriver "none"}}
 	r.HandleFunc("/health", s.healthHandler)

--- a/cmd/template/framework/files/routes/http_router.go.tmpl
+++ b/cmd/template/framework/files/routes/http_router.go.tmpl
@@ -15,7 +15,7 @@ import (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	r := httprouter.New()
-	r.HandlerFunc(http.MethodGet, "/", DummyMiddleware(s.HelloWorldHandler))
+	r.HandlerFunc(http.MethodGet, "/", Logger(s.HelloWorldHandler))
 
   {{if ne .DBDriver "none"}}
 	r.HandlerFunc(http.MethodGet, "/health", s.healthHandler)

--- a/cmd/template/framework/files/routes/http_router.go.tmpl
+++ b/cmd/template/framework/files/routes/http_router.go.tmpl
@@ -15,7 +15,7 @@ import (
 
 func (s *Server) RegisterRoutes() http.Handler {
 	r := httprouter.New()
-	r.HandlerFunc(http.MethodGet, "/", s.HelloWorldHandler)
+	r.HandlerFunc(http.MethodGet, "/", DummyMiddleware(s.HelloWorldHandler))
 
   {{if ne .DBDriver "none"}}
 	r.HandlerFunc(http.MethodGet, "/health", s.healthHandler)

--- a/cmd/template/framework/files/routes/standard_library.go.tmpl
+++ b/cmd/template/framework/files/routes/standard_library.go.tmpl
@@ -24,7 +24,7 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{end}}
   {{.AdvancedTemplates.TemplateRoutes}}
 
-	mwStack := MiddlewareStack(DummyMiddleware)
+	mwStack := MiddlewareStack(Logger)
 
 	return mwStack(mux)
 }

--- a/cmd/template/framework/files/routes/standard_library.go.tmpl
+++ b/cmd/template/framework/files/routes/standard_library.go.tmpl
@@ -24,7 +24,9 @@ func (s *Server) RegisterRoutes() http.Handler {
   {{end}}
   {{.AdvancedTemplates.TemplateRoutes}}
 
-	return mux
+	mwStack := MiddlewareStack(DummyMiddleware)
+
+	return mwStack(mux)
 }
 
 func (s *Server) HelloWorldHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/template/framework/ginRoutes.go
+++ b/cmd/template/framework/ginRoutes.go
@@ -12,6 +12,9 @@ var ginRoutesTemplate []byte
 //go:embed files/tests/gin-test.go.tmpl
 var ginTestHandlerTemplate []byte
 
+//go:embed files/middleware/gin.go.tmpl
+var ginMiddlewareTemplate []byte
+
 // GinTemplates contains the methods used for building
 // an app that uses [github.com/gin-gonic/gin]
 type GinTemplates struct{}
@@ -22,6 +25,10 @@ func (g GinTemplates) Main() []byte {
 
 func (g GinTemplates) Server() []byte {
 	return standardServerTemplate
+}
+
+func (g GinTemplates) Middleware() []byte {
+	return ginMiddlewareTemplate
 }
 
 func (g GinTemplates) Routes() []byte {

--- a/cmd/template/framework/gorillaRoutes.go
+++ b/cmd/template/framework/gorillaRoutes.go
@@ -9,6 +9,9 @@ import (
 //go:embed files/routes/gorilla.go.tmpl
 var gorillaRoutesTemplate []byte
 
+//go:embed files/middleware/gorilla.go.tmpl
+var gorillaMiddlewareTemplate []byte
+
 //go:embed files/tests/default-test.go.tmpl
 var gorillaTestHandlerTemplate []byte
 
@@ -22,6 +25,10 @@ func (g GorillaTemplates) Main() []byte {
 
 func (g GorillaTemplates) Server() []byte {
 	return standardServerTemplate
+}
+
+func (g GorillaTemplates) Middleware() []byte {
+	return gorillaMiddlewareTemplate
 }
 
 func (g GorillaTemplates) Routes() []byte {

--- a/cmd/template/framework/httpRoutes.go
+++ b/cmd/template/framework/httpRoutes.go
@@ -12,6 +12,9 @@ var standardRoutesTemplate []byte
 //go:embed files/server/standard_library.go.tmpl
 var standardServerTemplate []byte
 
+//go:embed files/middleware/standard_library.go.tmpl
+var standardMiddlewareTemplate []byte
+
 //go:embed files/tests/default-test.go.tmpl
 var standardTestHandlerTemplate []byte
 
@@ -25,6 +28,10 @@ func (s StandardLibTemplate) Main() []byte {
 
 func (s StandardLibTemplate) Server() []byte {
 	return standardServerTemplate
+}
+
+func (s StandardLibTemplate) Middleware() []byte {
+	return standardMiddlewareTemplate
 }
 
 func (s StandardLibTemplate) Routes() []byte {

--- a/cmd/template/framework/routerRoutes.go
+++ b/cmd/template/framework/routerRoutes.go
@@ -9,6 +9,9 @@ import (
 //go:embed files/routes/http_router.go.tmpl
 var httpRouterRoutesTemplate []byte
 
+//go:embed files/middleware/http_router.go.tmpl
+var httpRouterMiddlewareTemplate []byte
+
 //go:embed files/tests/default-test.go.tmpl
 var httpRouterTestHandlerTemplate []byte
 
@@ -19,8 +22,13 @@ type RouterTemplates struct{}
 func (r RouterTemplates) Main() []byte {
 	return mainTemplate
 }
+
 func (r RouterTemplates) Server() []byte {
 	return standardServerTemplate
+}
+
+func (r RouterTemplates) Middleware() []byte {
+	return httpRouterMiddlewareTemplate
 }
 
 func (r RouterTemplates) Routes() []byte {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

This PR contains code to add middleware wiring for all frameworks, including example middleware based on the documentation for the respective framework.

## Description of Changes: 

- Added middleware file, in server package
- Added Middleware renderer to  Templater interface
- Middleware example and use in router is included by default in all frameworks

## Checklist

- [X] I have self-reviewed the changes being requested
- [] I have updated the documentation (if applicable)
