### PR TITLE
bugfix: added special treatment of advanced flag in tip string

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -30,6 +30,10 @@ func NonInteractiveCommand(use string, flagSet *pflag.FlagSet) string {
 					}
 				}
 				nonInteractiveCommand += featureFlagsString
+			} else if flag.Value.Type() == "bool" {
+				if flag.Value.String() == "true" {
+					nonInteractiveCommand = fmt.Sprintf("%s --%s", nonInteractiveCommand, flag.Name)
+				}
 			} else {
 				nonInteractiveCommand = fmt.Sprintf("%s --%s %s", nonInteractiveCommand, flag.Name, flag.Value.String())
 			}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The line that prints after the program exits. giving a quick command line version of the same options, had a bug in it that would show the --advanced true/false no matter what. This flag doesn't need a true or a false value to be passed in, only its inclusion is enough to go to advanced mode.

## Description of Changes: 

- Added check for all bool-flags, and changed the generated command accordingly. This is only applicable to advanced-flag, but will work for all bool-flags in the future.

## Checklist

- [X] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
