### PR TITLE
fix: new url to install air

### DIFF
--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -48,7 +48,7 @@ watch:
 	else \
 	    read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
 	    if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-	        go install github.com/cosmtrek/air@latest; \
+	        go install github.com/air-verse/air@latest; \
 	        air; \
 	        echo "Watching...";\
 	    else \


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The maintainer of the air project has changed the URL of the project to github.com/air-verse/air@latest, following discussion here: https://github.com/air-verse/air/issues/605 

## Description of Changes: 

- Changed install command in makefile template

## Checklist

- [X] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (if applicable)
