### PR TITLE
remove an extra if statement in program.go

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -477,10 +477,6 @@ func (p *Project) CreateMainFile() error {
 				log.Printf("Could not install go dependency %v\n", err)
 				cobra.CheckErr(err)
 			}
-			if err != nil {
-				log.Printf("Could not install go dependency %v\n", err)
-				cobra.CheckErr(err)
-			}
 		} else {
 			helloGoTemplate := template.Must(template.New("efs").Parse((string(advanced.HelloGoTemplate()))))
 			err = helloGoTemplate.Execute(helloGoFile, p)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature
there was an extra if statement that led to the program excute an if twice