### PR TITLE
fix(fiber): Packaged assets not being served 

### DIFF
--- a/cmd/template/advanced/files/htmx/imports/fiber.tmpl
+++ b/cmd/template/advanced/files/htmx/imports/fiber.tmpl
@@ -1,3 +1,5 @@
 "github.com/a-h/templ"
 "{{.ProjectName}}/cmd/web"
 "github.com/gofiber/fiber/v2/middleware/adaptor"
+"github.com/gofiber/fiber/v2/middleware/filesystem"
+"net/http"

--- a/cmd/template/advanced/files/htmx/routes/fiber.tmpl
+++ b/cmd/template/advanced/files/htmx/routes/fiber.tmpl
@@ -1,4 +1,8 @@
-s.App.Static("/assets", "./cmd/web/assets")
+s.App.Use("/assets", filesystem.New(filesystem.Config{
+		Root:       http.FS(web.Files),
+		PathPrefix: "assets",
+		Browse:     false,
+	}))
 
 s.App.Get("/web", adaptor.HTTPHandler(templ.Handler(web.HelloForm())))
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Observed that after building the final output for a project with HTMX and Fiber Server, the files in the embedded assets were not being properly served to the client (404 not found error for the htmx javascript file and the styles file).

## Description of Changes: 

- Used the fiber filesystem middleware to serve the required files

## Checklist

- [x] I have self-reviewed the changes being requested