### PR TITLE
feat: add flag to skip git initialization

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -49,6 +49,7 @@ func init() {
 	createCmd.Flags().VarP(&flagFramework, "framework", "f", fmt.Sprintf("Framework to use. Allowed values: %s", strings.Join(flags.AllowedProjectTypes, ", ")))
 	createCmd.Flags().VarP(&flagDBDriver, "driver", "d", fmt.Sprintf("Database drivers to use. Allowed values: %s", strings.Join(flags.AllowedDBDrivers, ", ")))
 	createCmd.Flags().BoolP("advanced", "a", false, "Get prompts for advanced features")
+	createCmd.Flags().BoolP("skip-git", "s", false, "Do not initialize git")
 	createCmd.Flags().Var(&advancedFeatures, "feature", fmt.Sprintf("Advanced feature to use. Allowed values: %s", strings.Join(flags.AllowedAdvancedFeatures, ", ")))
 }
 
@@ -231,8 +232,14 @@ var createCmd = &cobra.Command{
 			}
 		}()
 
+		hasSkipGitFlag, flagErr := cmd.Flags().GetBool("skip-git")
+
+		if flagErr != nil {
+			log.Fatal("failed to retrieve skip flag")
+		}
+
 		// This calls the templates
-		err = project.CreateMainFile()
+		err = project.CreateMainFile(hasSkipGitFlag)
 		if err != nil {
 			if releaseErr := spinner.ReleaseTerminal(); releaseErr != nil {
 				log.Printf("Problem releasing terminal: %v", releaseErr)

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -212,7 +212,7 @@ func (p *Project) createDockerMap() {
 
 // CreateMainFile creates the project folders and files,
 // and writes to them depending on the selected options
-func (p *Project) CreateMainFile() error {
+func (p *Project) CreateMainFile(hasSkipGitFlag bool) error {
 	// check if AbsolutePath exists
 	if _, err := os.Stat(p.AbsolutePath); os.IsNotExist(err) {
 		// create directory
@@ -226,7 +226,7 @@ func (p *Project) CreateMainFile() error {
 	if err != nil {
 		cobra.CheckErr(err)
 	}
-	if !nameSet {
+	if !nameSet && !hasSkipGitFlag {
 		fmt.Println("user.name is not set in git config.")
 		fmt.Println("Please set up git config before trying again.")
 		panic("\nGIT CONFIG ISSUE: user.name is not set in git config.\n")
@@ -237,7 +237,7 @@ func (p *Project) CreateMainFile() error {
 	if err != nil {
 		cobra.CheckErr(err)
 	}
-	if !emailSet {
+	if !emailSet && !hasSkipGitFlag {
 		fmt.Println("user.email is not set in git config.")
 		fmt.Println("Please set up git config before trying again.")
 		panic("\nGIT CONFIG ISSUE: user.email is not set in git config.\n")
@@ -592,12 +592,15 @@ func (p *Project) CreateMainFile() error {
 		return err
 	}
 
-	// Initialize git repo
-	err = utils.ExecuteCmd("git", []string{"init"}, projectPath)
-	if err != nil {
-		log.Printf("Error initializing git repo: %v", err)
-		cobra.CheckErr(err)
-		return err
+	if !hasSkipGitFlag {
+		// Initialize git repo
+		err = utils.ExecuteCmd("git", []string{"init"}, projectPath)
+		if err != nil {
+			log.Printf("Error initializing git repo: %v", err)
+			cobra.CheckErr(err)
+			return err
+		}
+
 	}
 	// Create gitignore
 	gitignoreFile, err := os.Create(filepath.Join(projectPath, ".gitignore"))
@@ -642,19 +645,21 @@ func (p *Project) CreateMainFile() error {
 		cobra.CheckErr(err)
 		return err
 	}
-	// Git add files
-	err = utils.ExecuteCmd("git", []string{"add", "."}, projectPath)
-	if err != nil {
-		log.Printf("Error adding files to git repo: %v", err)
-		cobra.CheckErr(err)
-		return err
-	}
-	// Git commit files
-	err = utils.ExecuteCmd("git", []string{"commit", "-m", "Initial commit"}, projectPath)
-	if err != nil {
-		log.Printf("Error committing files to git repo: %v", err)
-		cobra.CheckErr(err)
-		return err
+	if !hasSkipGitFlag {
+		// Git add files
+		err = utils.ExecuteCmd("git", []string{"add", "."}, projectPath)
+		if err != nil {
+			log.Printf("Error adding files to git repo: %v", err)
+			cobra.CheckErr(err)
+			return err
+		}
+		// Git commit files
+		err = utils.ExecuteCmd("git", []string{"commit", "-m", "Initial commit"}, projectPath)
+		if err != nil {
+			log.Printf("Error committing files to git repo: %v", err)
+			cobra.CheckErr(err)
+			return err
+		}
 	}
 	return nil
 }

--- a/docs/docs/creating-project/project-init.md
+++ b/docs/docs/creating-project/project-init.md
@@ -23,6 +23,7 @@ In this example:
 - `--name`: Specifies the name of the project (replace "my-project" with your desired project name).
 - `--framework`: Specifies the Go framework to be used (e.g., "gin").
 - `--driver`: Specifies the database driver to be integrated (e.g., "postgres").
+- `--skip-git`: Specifies whether you want to avoid initializing git.
 
 Customize the flags according to your project requirements.
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Sometimes you want to manage git config by repo not global, so this PR includes a flag to skip all the git initialization commands, except for the .gitignore injection.

## Description of Changes: 

- Add a boolean flag called `--skip-git` or `-s`
- Add parameter to the `project.CreateMainFile` function to check whether this flag is set or not
- Add condition to all the git checks in the `CreateMainFile` function using this new value

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
