### PR TITLE
Ignore no git user.email if we're skipping git

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -228,10 +228,13 @@ func (p *Project) CreateMainFile() error {
 	if err != nil {
 		cobra.CheckErr(err)
 	}
-	if !emailSet {
-		fmt.Println("user.email is not set in git config.")
-		fmt.Println("Please set up git config before trying again.")
-		panic("\nGIT CONFIG ISSUE: user.email is not set in git config.\n")
+
+	if p.GitOptions.String() != flags.Skip {
+		if !emailSet {
+			fmt.Println("user.email is not set in git config.")
+			fmt.Println("Please set up git config before trying again.")
+			panic("\nGIT CONFIG ISSUE: user.email is not set in git config.\n")
+		}
 	}
 
 	p.ProjectName = strings.TrimSpace(p.ProjectName)


### PR DESCRIPTION
Advanced git-configs like includeIf break (see #238), this at least allows users to handle git on their own, later

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

[Please include a description of the problem or feature this PR is addressing.](https://github.com/Melkeydev/go-blueprint/issues/238)

## Description of Changes: 

- Ignore git user.email check if git config == skip

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
