### PR TITLE
[bug] live reload fixed

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"text/template"
 
@@ -37,6 +38,7 @@ type Project struct {
 	AdvancedOptions   map[string]bool
 	AdvancedTemplates AdvancedTemplates
 	GitOptions        flags.Git
+	UnixBased         bool
 }
 
 type AdvancedTemplates struct {
@@ -115,6 +117,14 @@ const (
 	gitHubActionPath     = ".github/workflows"
 	testHandlerPath      = "tests"
 )
+
+// CheckOs checks Operation system and generates MakeFile and `go build` command
+// Based on Project.Unixbase
+func (p *Project) CheckOs() {
+	if runtime.GOOS != "windows" {
+		p.UnixBased = true
+	}
+}
 
 // ExitCLI checks if the Project has been exited, and closes
 // out of the CLI if it has
@@ -245,6 +255,9 @@ func (p *Project) CreateMainFile() error {
 			return err
 		}
 	}
+
+	// Define Operating system
+	p.CheckOs()
 
 	// Create the map for our program
 	p.createFrameworkMap()

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -672,14 +672,6 @@ func (p *Project) CreateMainFile() error {
 			}
 		}
 	}
-
-	// Air auto installation
-	//err = p.AirAutoInstallation(projectPath)
-	//if err != nil {
-	//	log.Printf("Error in installing Air: %v", err)
-	//	cobra.CheckErr(err)
-	//	return err
-	//}
 	return nil
 }
 

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -672,6 +672,14 @@ func (p *Project) CreateMainFile() error {
 			}
 		}
 	}
+
+	// Air auto installation
+	//err = p.AirAutoInstallation(projectPath)
+	//if err != nil {
+	//	log.Printf("Error in installing Air: %v", err)
+	//	cobra.CheckErr(err)
+	//	return err
+	//}
 	return nil
 }
 

--- a/cmd/template/framework/files/air.toml.tmpl
+++ b/cmd/template/framework/files/air.toml.tmpl
@@ -4,7 +4,7 @@ tmp_dir = "tmp"
 
 [build]
   args_bin = []
-  bin = "./main"
+  bin = {{if .UnixBased }}"./main"{{ else }}".\\main.exe"{{ end }}
   cmd = "make build"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -7,7 +7,7 @@ build:
 	@echo "Building..."
 	{{if or ( .AdvancedOptions.htmx ) ( .AdvancedOptions.tailwind )}}@templ generate{{end}}
 	{{if .AdvancedOptions.tailwind}}@tailwindcss -i cmd/web/assets/css/input.css -o cmd/web/assets/css/output.css{{end}}
-	@go build -o main cmd/api/main.go
+	{{if .UnixBased }}@go build -o main cmd/api/main.go{{ else }}@go build -o main.exe cmd/api/main.go{{ end }}
 
 # Run the application
 run:

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -51,9 +51,9 @@ clean:
 	@rm -f main
 
 # Live Reload
-watch:
 {{if .UnixBased}}
-    @if command -v air > /dev/null; then \
+watch:
+	@if command -v air > /dev/null; then \
             air; \
             echo "Watching...";\
         else \
@@ -66,7 +66,10 @@ watch:
                 echo "You chose not to install air. Exiting..."; \
                 exit 1; \
             fi; \
-        fi{{else}}	@air
+        fi
+{{else}}
+watch:
+	@air
 {{end}}
 
 .PHONY: all build run test clean watch

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -51,20 +51,25 @@ clean:
 	@rm -f main
 
 # Live Reload
+{{if .UnixBased}}
 watch:
-	@if command -v air > /dev/null; then \
-	    air; \
-	    echo "Watching...";\
-	else \
-	    read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
-	    if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-	        go install github.com/air-verse/air@latest; \
-	        air; \
-	        echo "Watching...";\
-	    else \
-	        echo "You chose not to install air. Exiting..."; \
-	        exit 1; \
-	    fi; \
-	fi
+    @if command -v air > /dev/null; then \
+            air; \
+            echo "Watching...";\
+        else \
+            read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
+            if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
+                go install github.com/air-verse/air@latest; \
+                air; \
+                echo "Watching...";\
+            else \
+                echo "You chose not to install air. Exiting..."; \
+                exit 1; \
+            fi; \
+        fi
+{{else}}
+watch:
+	@air
+{{end}}
 
 .PHONY: all build run test clean

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -51,8 +51,8 @@ clean:
 	@rm -f main
 
 # Live Reload
-{{if .UnixBased}}
 watch:
+{{if .UnixBased}}
     @if command -v air > /dev/null; then \
             air; \
             echo "Watching...";\
@@ -66,10 +66,7 @@ watch:
                 echo "You chose not to install air. Exiting..."; \
                 exit 1; \
             fi; \
-        fi
-{{else}}
-watch:
-	@air
+        fi{{else}}	@air
 {{end}}
 
-.PHONY: all build run test clean
+.PHONY: all build run test clean watch


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature


air live reload will be working on both Unixbased and Windows machines

## Description of Changes: 

- Related to issue ticket #282 

1. `UnixBased` with bool type is added to `Project` type
2. CheckOs() function is added for checking the UNIX-based operating system if it's not windows leaves the `UnixBased` to false by default
```go
func (p *Project) CheckOs() {
	if runtime.GOOS != "windows" {
		p.UnixBased = true
	}
}
```
3. CheckOs() is executing in program.go:260
```go
// Define Operating system
p.CheckOs()
```
4. makefile.tmpl and air.toml.tmpl are modified

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
