### PR TITLE
move handler_test.go to internal/server package

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -113,7 +113,6 @@ const (
 	internalServerPath   = "internal/server"
 	internalDatabasePath = "internal/database"
 	gitHubActionPath     = ".github/workflows"
-	testHandlerPath      = "tests"
 )
 
 // ExitCLI checks if the Project has been exited, and closes
@@ -321,19 +320,6 @@ func (p *Project) CreateMainFile() error {
 	}
 
 	err = p.CreateFileWithInjection(cmdApiPath, projectPath, "main.go", "main")
-	if err != nil {
-		cobra.CheckErr(err)
-		return err
-	}
-
-	err = p.CreatePath(testHandlerPath, projectPath)
-	if err != nil {
-		log.Printf("Error creating path: %s", projectPath)
-		cobra.CheckErr(err)
-		return err
-	}
-	// inject testhandler template
-	err = p.CreateFileWithInjection(testHandlerPath, projectPath, "handler_test.go", "tests")
 	if err != nil {
 		cobra.CheckErr(err)
 		return err
@@ -560,6 +546,13 @@ func (p *Project) CreateMainFile() error {
 		cobra.CheckErr(err)
 		return err
 	}
+
+	err = p.CreateFileWithInjection(internalServerPath, projectPath, "routes_test.go", "tests")
+	if err != nil {
+		cobra.CheckErr(err)
+		return err
+	}
+
 	err = p.CreateFileWithInjection(internalServerPath, projectPath, "server.go", "server")
 	if err != nil {
 		log.Printf("Error injecting server.go file: %v", err)

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -36,7 +36,7 @@ docker-down:
 # Test the application
 test:
 	@echo "Testing..."
-	@go test ./tests -v
+	@go test ./... -v
 
 # Clean the binary
 clean:

--- a/cmd/template/framework/files/tests/default-test.go.tmpl
+++ b/cmd/template/framework/files/tests/default-test.go.tmpl
@@ -1,13 +1,12 @@
-package tests
+package server
 import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"{{.ProjectName}}/internal/server"
 	"testing"
 )
 func TestHandler(t *testing.T) {
-    s := &server.Server{}
+    s := &Server{}
     server := httptest.NewServer(http.HandlerFunc(s.HelloWorldHandler))
     defer server.Close()
     resp, err := http.Get(server.URL)

--- a/cmd/template/framework/files/tests/echo-test.go.tmpl
+++ b/cmd/template/framework/files/tests/echo-test.go.tmpl
@@ -1,10 +1,9 @@
-package tests
+package server
 import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"{{.ProjectName}}/internal/server"
 	"testing"
 	"github.com/labstack/echo/v4"
 )
@@ -13,7 +12,7 @@ func TestHandler(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	resp := httptest.NewRecorder()
 	c := e.NewContext(req, resp)
-	s := &server.Server{}
+	s := &Server{}
 	// Assertions
 	if err := s.HelloWorldHandler(c); err != nil {
 		t.Errorf("handler() error = %v", err)

--- a/cmd/template/framework/files/tests/fiber-test.go.tmpl
+++ b/cmd/template/framework/files/tests/fiber-test.go.tmpl
@@ -1,8 +1,7 @@
-package tests
+package server
 import (
 	"io"
 	"net/http"
-	"{{.ProjectName}}/internal/server"
 	"testing"
 	"github.com/gofiber/fiber/v2"
 )
@@ -10,7 +9,7 @@ func TestHandler(t *testing.T) {
 	// Create a Fiber app for testing
 	app := fiber.New()
 	// Inject the Fiber app into the server
-	s := &server.FiberServer{App: app}
+	s := &FiberServer{App: app}
 	// Define a route in the Fiber app
 	app.Get("/", s.HelloWorldHandler)
 	// Create a test HTTP request

--- a/cmd/template/framework/files/tests/gin-test.go.tmpl
+++ b/cmd/template/framework/files/tests/gin-test.go.tmpl
@@ -1,13 +1,12 @@
-package tests
+package server
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"github.com/gin-gonic/gin"
-	"{{.ProjectName}}/internal/server"
 )
 func TestHelloWorldHandler(t *testing.T) {
-	s := &server.Server{}
+	s := &Server{}
 	r := gin.New()
 	r.GET("/", s.HelloWorldHandler)
 	// Create a test HTTP request

--- a/docs/docs/advanced-flag/tailwind.md
+++ b/docs/docs/advanced-flag/tailwind.md
@@ -24,9 +24,8 @@ The project tree would look like this:
 ├── internal/
 │   └── server/
 │       ├── routes.go
+│       ├── routes_test.go 
 │       └── server.go
-├── tests/
-│   └── handler_test.go
 ├── go.mod
 ├── go.sum
 ├── Makefile

--- a/docs/docs/blueprint-core/db-drivers.md
+++ b/docs/docs/blueprint-core/db-drivers.md
@@ -20,9 +20,8 @@ Integrating a database adds a new layer to the project structure, primarily in t
 │   │   └── database.go
 │   └── /server
 │       ├── routes.go
+│       ├── routes_test.go
 │       └── server.go
-├── /tests
-│   └── handler_test.go
 ├── go.mod
 ├── go.sum
 ├── Makefile

--- a/docs/docs/blueprint-core/frameworks.md
+++ b/docs/docs/blueprint-core/frameworks.md
@@ -19,9 +19,8 @@ The project is structured with a simple layout, focusing on the cmd, internal, a
 ├── /internal
 │   └── /server
 │       ├── routes.go
+│       ├── routes_test.go
 │       └── server.go
-├── /tests
-│   └── handler_test.go
 ├── go.mod
 ├── go.sum
 ├── Makefile

--- a/docs/docs/creating-project/makefile.md
+++ b/docs/docs/creating-project/makefile.md
@@ -29,7 +29,7 @@ make docker-down
 ```
 
 - **Test the Application:**
-Executes tests defined in the `./tests` directory.
+Executes all tests defined in the project.
 ```bash
 make test
 ```

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -50,9 +50,8 @@ Here's an overview of the project structure created by Go Blueprint when all opt
 │   │   └── database.go           # File containing functions related to database operations.
 │   └── server/
 │       ├── routes.go             # File defining HTTP routes.
+│       ├── routes_test.go        # Test file for testing HTTP handlers.
 │       └── server.go             # Main server logic.
-├── tests/
-│   └── handler_test.go           # Test file for testing HTTP handlers.
 ├── .air.toml                     # Configuration file for Air, a live-reload utility.
 ├── docker-compose.yml            # Docker Compose configuration for defining DB config.
 ├── .env                          # Environment configuration file.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Resolves #280 

## Description of Changes: 

- moved handler_test.go to internal/server package and renamed to routes_test.go
- updated docs referring to handler_test.go in the previous location

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
