### PR TITLE
Added Rustywind CLI for formatting Tailwind classes

### DIFF
--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -6,6 +6,8 @@ all: build
 build:
 	@echo "Building..."
 	{{if or ( .AdvancedOptions.htmx ) ( .AdvancedOptions.tailwind )}}@templ generate{{end}}
+	{{if .AdvancedOptions.tailwind}}@rustywind cmd/web/assets/css/input.css --write {{end}}
+	{{if .AdvancedOptions.tailwind}}@rustywind --write $(shell find cmd/web -name '*.templ'){{end}}
 	{{if .AdvancedOptions.tailwind}}@tailwindcss -i cmd/web/assets/css/input.css -o cmd/web/assets/css/output.css{{end}}
 	@go build -o main cmd/api/main.go
 

--- a/docs/docs/advanced-flag/tailwind.md
+++ b/docs/docs/advanced-flag/tailwind.md
@@ -3,6 +3,7 @@ Tailwind is closely coupled with the advanced HTMX flag, and HTMX will be automa
 We do not introduce outside dependencies automatically, and you need compile output.css (file is empty by default) with the Tailwind CLI tool.
 
 The project tree would look like this:
+
 ```bash
 / (Root)
 ├── cmd/
@@ -24,7 +25,7 @@ The project tree would look like this:
 ├── internal/
 │   └── server/
 │       ├── routes.go
-│       ├── routes_test.go 
+│       ├── routes_test.go
 │       └── server.go
 ├── go.mod
 ├── go.sum
@@ -58,3 +59,19 @@ chmod +x tailwindcss-linux-x64
 By default, CSS examples are not included in the codebase.
 Update base.templ and hello.templ, then rerun templ generate to see the changes at the localhost:PORT/web endpoint.
 
+## Standalone Rustywind
+
+[Rustywind](https://github.com/avencera/rustywind) is a CLI tool for oraganizing and formatting Tailwind classes by [avencera](https://github.com/avencera)
+
+```bash
+curl -LSfs https://avencera.github.io/rustywind/install.sh | sh -s -- --git avencera/rustywind
+```
+
+## Rustywind formatting
+
+Rustywind will check and format all `.templ` files inside cmd/web folder
+
+```bash
+rustywind cmd/web/assets/css/input.css --write
+rustywind --write $(shell find cmd/web -name '*.templ')
+```


### PR DESCRIPTION
## Problem/Feature

Add support for Rustywind CLI to format Tailwind CSS classes.

## Description of Changes

- Integrated Rustywind CLI commands into the `makefile.templ` for formatting and sorting Tailwind classes in `.templ` files within the `cmd/web` directory.

## Checklist

- [x] I have self-reviewed the changes being requested.
- [x] I have updated the documentation
