### PR TITLE
refactor: use slices.Contains instead of for loop to check if the provided db is in AllowedDBDrivers

### DIFF
--- a/cmd/flags/database.go
+++ b/cmd/flags/database.go
@@ -2,6 +2,7 @@ package flags
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -30,13 +31,9 @@ func (f *Database) Type() string {
 }
 
 func (f *Database) Set(value string) error {
-	// Contains isn't available in 1.20 yet
-	// if AllowedDBDrivers.Contains(value) {
-	for _, database := range AllowedDBDrivers {
-		if database == value {
-			*f = Database(value)
-			return nil
-		}
+	if slices.Contains(AllowedDBDrivers, value) {
+		*f = Database(value)
+		return nil
 	}
 
 	return fmt.Errorf("Database to use. Allowed values: %s", strings.Join(AllowedDBDrivers, ", "))


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature


## Description of Changes: 

- use slices.Contains instead of for loop to check if the provided db is in AllowedDBDrivers

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
