### PR TITLE
feat: Check if templ and tailwindcss commands are available before

### DIFF
--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -2,8 +2,14 @@
 
 # Build the application
 all: build
+{{if or ( .AdvancedOptions.htmx ) ( .AdvancedOptions.tailwind )}}
 
-build:
+check:
+	@command -v templ >/dev/null 2>&1 || { echo >&2 "templ is not installed. Run 'go install go install github.com/a-h/templ/cmd/templ@latest' to install it or check your environment."; exit 1; }
+	@command -v tailwindcss  >/dev/null 2>&1 || { echo >&2 "tailwindcss is not install. Go to https://tailwindcss.com/docs/installation to install it or check your environment."; exit 1; }
+
+{{end}}
+build:{{if or ( .AdvancedOptions.htmx ) ( .AdvancedOptions.tailwind )}} check{{end}}
 	@echo "Building..."
 	{{if or ( .AdvancedOptions.htmx ) ( .AdvancedOptions.tailwind )}}@templ generate{{end}}
 	{{if .AdvancedOptions.tailwind}}@tailwindcss -i cmd/web/assets/css/input.css -o cmd/web/assets/css/output.css{{end}}


### PR DESCRIPTION
building (#295)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

When creating a new project for the first time, and having tailwindcss and templ options enable, the Makefile does not check if those commands are available. I'm adding a "check" step in the Makefile to do this, and redirect the user to installed them if they are not available.

## Description of Changes: 

- Makefile: Added `check` step if tailwindcss and templ options are enabled

## Checklist

- [x] I have self-reviewed the changes being requested
- [N/A] I have updated the documentation (check issue ticket #218)
