### PR TITLE
Updated `nhooyr.io/websocket` to `github.com/coder/websocket`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can now use the `--advanced` flag when running the `create` command to get a
 
 - [HTMX](https://htmx.org/) support using [Templ](https://templ.guide/)
 - CI/CD workflow setup using [Github Actions](https://docs.github.com/en/actions)
-- [Websocket](https://pkg.go.dev/nhooyr.io/websocket) sets up a websocket endpoint
+- [Websocket](https://pkg.go.dev/github.com/coder/websocket) sets up a websocket endpoint
 - [Tailwind](https://tailwindcss.com/) css framework
 
 Note: selecting tailwind option automatically selects htmx.

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -785,7 +785,7 @@ func (p *Project) CreateHtmxTemplates() {
 }
 
 func (p *Project) CreateWebsocketImports(appDir string) {
-	websocketDependency := []string{"nhooyr.io/websocket"}
+	websocketDependency := []string{"github.com/coder/websocket"}
 	if p.ProjectType == flags.Fiber {
 		websocketDependency = []string{"github.com/gofiber/contrib/websocket"}
 	}

--- a/cmd/template/advanced/files/websocket/imports/standard_library.tmpl
+++ b/cmd/template/advanced/files/websocket/imports/standard_library.tmpl
@@ -1,1 +1,1 @@
-"nhooyr.io/websocket"
+"github.com/coder/websocket"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The websocket package that was used `nhooyr.io/websocket` was moved to `https://github.com/coder/websocket`
## Description of Changes: 

- Updated docs
- Search replaced old lib with new one

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
