### PR TITLE
Accept module name as input to create command

### DIFF
--- a/.github/workflows/generate-linter-advanced.yml
+++ b/.github/workflows/generate-linter-advanced.yml
@@ -30,19 +30,23 @@ jobs:
           git config --global user.name 'testname'
           git config --global user.email 'testemail@users.noreply.github.com'
 
+      - name: Set framework variable
+        id: set-proejct-directory
+        run: echo "PROJECT_DIRECTORY=${{ matrix.framework }}" | sed 's/\//-/g' >> $GITHUB_ENV
+
       - name: build templates
-        run: script -q /dev/null -c "go run main.go create -n ${{ matrix.framework }} -f ${{ matrix.framework}} -d ${{ matrix.driver }} -g ${{ matrix.git}} --advanced --feature ${{ matrix.advanced }}" /dev/null
+        run: script -q /dev/null -c "go run main.go create -n ${{ env.PROJECT_DIRECTORY }} -f ${{ matrix.framework}} -d ${{ matrix.driver }} -g ${{ matrix.git}} --advanced --feature ${{ matrix.advanced }}" /dev/null
 
       - if: ${{ matrix.advanced == 'htmx' || matrix.advanced == 'tailwind' }}
         name: Install Templ & gen templates
         run: | 
           go install github.com/a-h/templ/cmd/templ@latest
-          /home/runner/go/bin/templ generate -path ${{ matrix.framework }}
+          /home/runner/go/bin/templ generate -path ${{ env.PROJECT_DIRECTORY }}
 
       - name: golangci-lint
         run: | 
-          cd ${{ matrix.framework }}
+          cd ${{ env.PROJECT_DIRECTORY }}
           golangci-lint run
 
       - name: remove templates
-        run: rm -rf ${{ matrix.framework }}
+        run: rm -rf ${{ env.PROJECT_DIRECTORY }}

--- a/.github/workflows/generate-linter-core.yml
+++ b/.github/workflows/generate-linter-core.yml
@@ -29,13 +29,17 @@ jobs:
           git config --global user.name 'testname'
           git config --global user.email 'testemail@users.noreply.github.com'
 
+      - name: Set framework variable
+        id: set-proejct-directory
+        run: echo "PROJECT_DIRECTORY=${{ matrix.framework }}" | sed 's/\//-/g' >> $GITHUB_ENV
+
       - name: build templates
-        run: script -q /dev/null -c "go run main.go create -n ${{ matrix.framework }} -f ${{ matrix.framework}} -d ${{ matrix.driver }} -g ${{ matrix.git}}" /dev/null
+        run: script -q /dev/null -c "go run main.go create -n ${{ env.PROJECT_DIRECTORY }} -f ${{ matrix.framework}} -d ${{ matrix.driver }} -g ${{ matrix.git}}" /dev/null
 
       - name: golangci-lint
         run: | 
-          cd ${{ matrix.framework }}
+          cd ${{ env.PROJECT_DIRECTORY }}
           golangci-lint run
 
       - name: remove templates
-        run: rm -rf ${{ matrix.framework }}
+        run: rm -rf ${{ env.PROJECT_DIRECTORY }}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -75,8 +75,15 @@ var createCmd = &cobra.Command{
 
 		isInteractive := false
 		flagName := cmd.Flag("name").Value.String()
-		if flagName != "" && doesDirectoryExistAndIsNotEmpty(flagName) {
-			err = fmt.Errorf("directory '%s' already exists and is not empty. Please choose a different name", flagName)
+
+		if flagName != "" && !utils.ValidateModuleName(flagName) {
+			err = fmt.Errorf("'%s' is not a valid module name. Please choose a different name", flagName)
+			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
+		}
+
+		rootDirName := utils.GetRootDir(flagName)
+		if rootDirName != "" && doesDirectoryExistAndIsNotEmpty(rootDirName) {
+			err = fmt.Errorf("directory '%s' already exists and is not empty. Please choose a different name", rootDirName)
 			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 		}
 
@@ -126,8 +133,15 @@ var createCmd = &cobra.Command{
 				log.Printf("Name of project contains an error: %v", err)
 				cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 			}
-			if doesDirectoryExistAndIsNotEmpty(options.ProjectName.Output) {
-				err = fmt.Errorf("directory '%s' already exists and is not empty. Please choose a different name", options.ProjectName.Output)
+
+			if options.ProjectName.Output != "" && !utils.ValidateModuleName(options.ProjectName.Output) {
+				err = fmt.Errorf("'%s' is not a valid module name. Please choose a different name", options.ProjectName.Output)
+				cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
+			}
+
+			rootDirName = utils.GetRootDir(options.ProjectName.Output)
+			if doesDirectoryExistAndIsNotEmpty(rootDirName) {
+				err = fmt.Errorf("directory '%s' already exists and is not empty. Please choose a different name", rootDirName)
 				cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 			}
 			project.ExitCLI(tprogram)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -278,7 +278,7 @@ var createCmd = &cobra.Command{
 		}
 
 		fmt.Println(endingMsgStyle.Render("\nNext steps:"))
-		fmt.Println(endingMsgStyle.Render(fmt.Sprintf("• cd into the newly created project with: `cd %s`\n", project.ProjectName)))
+		fmt.Println(endingMsgStyle.Render(fmt.Sprintf("• cd into the newly created project with: `cd %s`\n", utils.GetRootDir(project.ProjectName))))
 
 		if options.Advanced.Choices["Tailwind"] {
 			options.Advanced.Choices["Htmx"] = true

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -248,7 +248,7 @@ func (p *Project) CreateMainFile() error {
 	p.ProjectName = strings.TrimSpace(p.ProjectName)
 
 	// Create a new directory with the project name
-	projectPath := filepath.Join(p.AbsolutePath, p.ProjectName)
+	projectPath := filepath.Join(p.AbsolutePath, utils.GetRootDir(p.ProjectName))
 	if _, err := os.Stat(projectPath); os.IsNotExist(err) {
 		err := os.MkdirAll(projectPath, 0o751)
 		if err != nil {

--- a/cmd/ui/textinput/textinput.go
+++ b/cmd/ui/textinput/textinput.go
@@ -45,7 +45,7 @@ type model struct {
 
 // sanitizeInput verifies that an input text string gets validated
 func sanitizeInput(input string) error {
-	matched, err := regexp.Match("^[a-zA-Z0-9_-]+$", []byte(input))
+	matched, err := regexp.Match("^[a-zA-Z0-9_\\/.-]+$", []byte(input))
 	if !matched {
 		return fmt.Errorf("string violates the input regex pattern, err: %v", err)
 	}

--- a/cmd/ui/textinput/textinput_test.go
+++ b/cmd/ui/textinput/textinput_test.go
@@ -8,6 +8,8 @@ func TestInputSanitization(t *testing.T) {
 		"new_project",
 		"NEW_PROJECT",
 		"new-project",
+		"new/project",
+		"new.project",
 	}
 	for _, testCase := range passTestCases {
 		if err := sanitizeInput(testCase); err != nil {

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -119,4 +120,18 @@ func CheckGitConfig(key string) (bool, error) {
 	}
 	// The command ran successfully, so the key is set.
 	return true, nil
+}
+
+// ValidateModuleName returns true if it's a valid module name.
+// It allows any number of / and . characters in between.
+func ValidateModuleName(moduleName string) bool {
+	matched, _ := regexp.Match("^[a-zA-Z0-9_-]+(?:[\\/.][a-zA-Z0-9_-]+)*$", []byte(moduleName))
+	return matched
+}
+
+// GetRootDir returns the project directory name from the module path.
+// Returns the last token by splitting the moduleName with /
+func GetRootDir(moduleName string) string {
+	tokens := strings.Split(moduleName, "/")
+	return tokens[len(tokens)-1]
 }

--- a/cmd/utils/utils_test.go
+++ b/cmd/utils/utils_test.go
@@ -1,0 +1,57 @@
+package utils
+
+import "testing"
+
+func TestValidateModuleName(t *testing.T) {
+	passTestCases := []string{
+		"github.com/user/project",
+		"github.com/user/projec1-hyphen",
+		"github.com/user/projecT_under_Score",
+		"github.com/user/project.hyphen3",
+		"project",
+		"ProJEct",
+		"PRo_45-.4Jc",
+		"PRo_/4J/c",
+	}
+	for _, testCase := range passTestCases {
+		ok := ValidateModuleName(testCase)
+		if !ok {
+			t.Errorf("testing:%s expected:true got:%v", testCase, ok)
+		}
+	}
+
+	failTestCases := []string{
+		"",
+		"/",
+		".",
+		"//",
+		"/project",
+		"ProJEct/",
+		"PRo_$4Jc",
+		"PRo_@J/c",
+	}
+	for _, testCase := range failTestCases {
+		ok := ValidateModuleName(testCase)
+		if ok {
+			t.Errorf("testing:%s expected:false got:%v", testCase, ok)
+		}
+	}
+}
+
+func TestGeRootDir(t *testing.T) {
+	testCases := map[string]string{
+		"github.com/user/pro-ject": "pro-ject",
+		"pro-ject":                 "pro-ject",
+		"/":                        "",
+		"":                         "",
+		"//":                       "",
+		"@":                        "@",
+	}
+
+	for intput, output := range testCases {
+		rootDir := GetRootDir(intput)
+		if rootDir != output {
+			t.Errorf("testing:%s expected:%s got:%s", intput, output, rootDir)
+		}
+	}
+}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

go-blueprint create command was not working as expected if the user enters module name as an input rather than directory name.

Eg: go-blueprint create --name github.com/Patel-Raj/project1

This would create sub-directories github.com, Patel-Raj and project1 and then create the projects source code in project1 directory.

After this change, the Go project will be created at project1 as the root directory and the go.mod would have github.com/Patel-Raj/project1 as its module name.

Fixes: #285 

## Description of Changes: 

- Fetched directory name from the input string as the last token of the input when Split by /
- Relaxed the sanitization regex to allow / and . characters in the input.
- Used that the directory name to create the root directory.
- Added unit tests for the newly added util functions.

## Checklist

- [Y] I have self-reviewed the changes being requested
- [Y] I have updated the documentation (if applicable)
