### PR TITLE
Fix copy/paste typo in mongo.tmpl

### DIFF
--- a/cmd/template/dbdriver/files/tests/mongo.tmpl
+++ b/cmd/template/dbdriver/files/tests/mongo.tmpl
@@ -33,13 +33,13 @@ func mustStartMongoContainer() (func(context.Context) error, error) {
 func TestMain(m *testing.M) {
 	teardown, err := mustStartMongoContainer()
 	if err != nil {
-		log.Fatalf("could not start postgres container: %v", err)
+		log.Fatalf("could not start mongodb container: %v", err)
 	}
 
 	m.Run()
 
 	if teardown != nil && teardown(context.Background()) != nil {
-		log.Fatalf("could not teardown postgres container: %v", err)
+		log.Fatalf("could not teardown mongodb container: %v", err)
 	}
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Typo in error message if database test fails due to container problem.

## Description of Changes: 

- Replaced string `postgres` with `mongodb`

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
