### PR TITLE
add graceful shutdown for the http server.

### DIFF
--- a/cmd/template/framework/files/main/fiber_main.go.tmpl
+++ b/cmd/template/framework/files/main/fiber_main.go.tmpl
@@ -1,22 +1,52 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
+	"time"
 	"{{.ProjectName}}/internal/server"
 
 	_ "github.com/joho/godotenv/autoload"
 )
+
+func gracefulShutdown(fiberServer *server.FiberServer) {
+	// Create context that listens for the interrupt signal from the OS.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// Listen for the interrupt signal.
+	<-ctx.Done()
+
+	log.Println("shutting down gracefully, press Ctrl+C again to force")
+
+	// The context is used to inform the server it has 5 seconds to finish
+	// the request it is currently handling
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := fiberServer.ShutdownWithContext(ctx); err != nil {
+		log.Printf("Server forced to shutdown with error: %v", err)
+	}
+
+	log.Println("Server exiting")
+}
 
 func main() {
 
 	server := server.New()
 
 	server.RegisterFiberRoutes()
-	port, _ := strconv.Atoi(os.Getenv("PORT"))
-	err := server.Listen(fmt.Sprintf(":%d", port))
-	if err != nil {
-		panic(fmt.Sprintf("cannot start server: %s", err))
-	}
+	go func() {
+		port, _ := strconv.Atoi(os.Getenv("PORT"))
+		err := server.Listen(fmt.Sprintf(":%d", port))
+		if err != nil {
+			panic(fmt.Sprintf("http server error: %s", err))
+		}
+	}()
+
+	gracefulShutdown(server)
 }

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -41,7 +41,7 @@ func main() {
 	go gracefulShutdown(server)
 
 	err := server.ListenAndServe()
-	if err != nil {
+	if err != nil && err != http.ErrServerClosed {
 		panic(fmt.Sprintf("http server error: %s", err))
 	}
 }

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -1,16 +1,47 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"log"
+	"net/http"
+	"os/signal"
+	"syscall"
+	"time"
+
 	"{{.ProjectName}}/internal/server"
 )
+
+func gracefulShutdown(apiServer *http.Server) {
+	// Create context that listens for the interrupt signal from the OS.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// Listen for the interrupt signal.
+	<-ctx.Done()
+
+	log.Println("shutting down gracefully, press Ctrl+C again to force")
+
+	// The context is used to inform the server it has 5 seconds to finish
+	// the request it is currently handling
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := apiServer.Shutdown(ctx); err != nil {
+  		log.Printf("Server forced to shutdown with error: %v", err)
+	}
+
+	log.Println("Server exiting")
+}
+
 
 func main() {
 
 	server := server.NewServer()
 
+	go gracefulShutdown(server)
+
 	err := server.ListenAndServe()
 	if err != nil {
-		panic(fmt.Sprintf("cannot start server: %s", err))
+		panic(fmt.Sprintf("http server error: %s", err))
 	}
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

When the HTTP server is created it is important to have it gracefully shut down, and that is a boilerplate code that would be nice for go-blueprint to be able to add when the code is generated.

## Description of Changes: 

- add graceful shutdown for the HTTP server.
- change the error message printed when the server shuts down.
- fixes #205 

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
