### PR TITLE
chore: ignore .DS_Store file

### DIFF
--- a/cmd/template/framework/files/gitignore.tmpl
+++ b/cmd/template/framework/files/gitignore.tmpl
@@ -28,3 +28,6 @@ tmp/
 # Project build
 main
 *templ.go
+
+# OS X generated file
+.DS_Store


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

I believe we don't need to commit `.DS_Store` file

## Description of Changes: 

- Added the `.DS_Store` file, which is automatically generated by OS X, to the `.gitignore` file

## Checklist

- [ ] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
