### PR TITLE
bug/gracefulShutdown

### DIFF
--- a/cmd/template/framework/files/main/fiber_main.go.tmpl
+++ b/cmd/template/framework/files/main/fiber_main.go.tmpl
@@ -13,6 +13,7 @@ import (
 
 	_ "github.com/joho/godotenv/autoload"
 )
+
 func gracefulShutdown(fiberServer *server.FiberServer, done chan bool) {
 	// Create context that listens for the interrupt signal from the OS.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/template/framework/files/main/fiber_main.go.tmpl
+++ b/cmd/template/framework/files/main/fiber_main.go.tmpl
@@ -13,8 +13,7 @@ import (
 
 	_ "github.com/joho/godotenv/autoload"
 )
-
-func gracefulShutdown(fiberServer *server.FiberServer) {
+func gracefulShutdown(fiberServer *server.FiberServer, done chan bool) {
 	// Create context that listens for the interrupt signal from the OS.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -26,13 +25,16 @@ func gracefulShutdown(fiberServer *server.FiberServer) {
 
 	// The context is used to inform the server it has 5 seconds to finish
 	// the request it is currently handling
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := fiberServer.ShutdownWithContext(ctx); err != nil {
 		log.Printf("Server forced to shutdown with error: %v", err)
 	}
 
 	log.Println("Server exiting")
+
+	// Notify the main goroutine that the shutdown is complete
+	done <- true
 }
 
 func main() {
@@ -40,6 +42,10 @@ func main() {
 	server := server.New()
 
 	server.RegisterFiberRoutes()
+
+	// Create a done channel to signal when the shutdown is complete
+	done := make(chan bool, 1)
+
 	go func() {
 		port, _ := strconv.Atoi(os.Getenv("PORT"))
 		err := server.Listen(fmt.Sprintf(":%d", port))
@@ -48,5 +54,10 @@ func main() {
 		}
 	}()
 
-	gracefulShutdown(server)
+	// Run graceful shutdown in a separate goroutine
+	go gracefulShutdown(server, done)
+
+	// Wait for the graceful shutdown to complete
+	<-done
+	log.Println("Graceful shutdown complete.")
 }

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -11,8 +11,7 @@ import (
 
 	"{{.ProjectName}}/internal/server"
 )
-
-func gracefulShutdown(apiServer *http.Server) {
+func gracefulShutdown(apiServer *http.Server, done chan bool) {
 	// Create context that listens for the interrupt signal from the OS.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -24,24 +23,34 @@ func gracefulShutdown(apiServer *http.Server) {
 
 	// The context is used to inform the server it has 5 seconds to finish
 	// the request it is currently handling
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := apiServer.Shutdown(ctx); err != nil {
-  		log.Printf("Server forced to shutdown with error: %v", err)
+		log.Printf("Server forced to shutdown with error: %v", err)
 	}
 
 	log.Println("Server exiting")
-}
 
+	// Notify the main goroutine that the shutdown is complete
+	done <- true
+}
 
 func main() {
 
 	server := server.NewServer()
 
-	go gracefulShutdown(server)
+	// Create a done channel to signal when the shutdown is complete
+	done := make(chan bool, 1)
 
+	go gracefulShutdown(server, done)
+
+	// Start the server
 	err := server.ListenAndServe()
 	if err != nil && err != http.ErrServerClosed {
 		panic(fmt.Sprintf("http server error: %s", err))
 	}
+
+	// Wait for the graceful shutdown to complete
+	<-done
+	log.Println("Graceful shutdown complete.")
 }

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -43,9 +43,9 @@ func main() {
 	// Create a done channel to signal when the shutdown is complete
 	done := make(chan bool, 1)
 
+	// Run graceful shutdown in a separate goroutine
 	go gracefulShutdown(server, done)
 
-	// Start the server
 	err := server.ListenAndServe()
 	if err != nil && err != http.ErrServerClosed {
 		panic(fmt.Sprintf("http server error: %s", err))

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -11,6 +11,7 @@ import (
 
 	"{{.ProjectName}}/internal/server"
 )
+
 func gracefulShutdown(apiServer *http.Server, done chan bool) {
 	// Create context that listens for the interrupt signal from the OS.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem

ListenAndServe() method blocks the main goroutine, but when  gracefulShutdown(server) is called  in a separate goroutine, the Shutdown() function is triggered when an interrupt signal is received. 

if the server.ListenAndServe() call does not return http.ErrServerClosed, it indicates that the server did not shut down properly, causing the main goroutine to keep running and preventing a clean exit

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
