### PR TITLE
bug: Added missing meta viewport tag to HTMX base.templ.tmpl file

### DIFF
--- a/cmd/template/advanced/files/htmx/base.templ.tmpl
+++ b/cmd/template/advanced/files/htmx/base.templ.tmpl
@@ -5,6 +5,7 @@ templ Base() {
 	<html lang="en" {{if .AdvancedOptions.tailwind}}class="h-screen"{{end}}>
 		<head>
 			<meta charset="utf-8"/>
+			<meta name="viewport" content="width=device-width,initial-scale=1"/>
 			<title>Go Blueprint Hello</title>
 			<link href="assets/css/output.css" rel="stylesheet"/>
 			<script src="assets/js/htmx.min.js"></script>


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Missing meta viewport tag in HTMX base.templ.tmpl file causes styling issues with smaller devices.

## Description of Changes: 

- Added meta viewport tag to head of base.templ.tmpl file.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
