### PR TITLE
fix(readme): add missing hyphen to example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ go-blueprint create --advanced --feature react
 Or all features at once:
 
 ```bash
-go-blueprint create --name my-project --framework chi --driver mysql --advanced --feature htmx --feature githubaction --feature websocket --feature tailwind --feature docker -git commit --feature react
+go-blueprint create --name my-project --framework chi --driver mysql --advanced --feature htmx --feature githubaction --feature websocket --feature tailwind --feature docker --git commit --feature react
 ```
 
 <p align="center">


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem

Added missing hyphen to example command in README.md

## Checklist

- [x] I have self-reviewed the changes being requested
