### PR TITLE
fix: output.css being public

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -438,14 +438,14 @@ func (p *Project) CreateMainFile() error {
 			return err
 		}
 
-		inputCssFile, err := os.Create(fmt.Sprintf("%s/%s/assets/css/input.css", projectPath, cmdWebPath))
+		inputCssFile, err := os.Create(fmt.Sprintf("%s/%s/styles/input.css", projectPath, cmdWebPath))
 		if err != nil {
 			return err
 		}
 		defer inputCssFile.Close()
 
 		inputCssTemplate := advanced.InputCssTemplate()
-		err = os.WriteFile(fmt.Sprintf("%s/%s/assets/css/input.css", projectPath, cmdWebPath), inputCssTemplate, 0o644)
+		err = os.WriteFile(fmt.Sprintf("%s/%s/styles/input.css", projectPath, cmdWebPath), inputCssTemplate, 0o644)
 		if err != nil {
 			return err
 		}

--- a/cmd/template/advanced/files/docker/dockerfile.tmpl
+++ b/cmd/template/advanced/files/docker/dockerfile.tmpl
@@ -18,7 +18,7 @@ RUN go install github.com/a-h/templ/cmd/templ@latest && \
 {{- if .AdvancedOptions.tailwind}}
     curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 -o tailwindcss && \
     chmod +x tailwindcss && \
-    ./tailwindcss -i cmd/web/assets/css/input.css -o cmd/web/assets/css/output.css
+    ./tailwindcss -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css
 {{- end }}
 
 RUN {{ if (eq .DBDriver "sqlite") }}CGO_ENABLED=1 GOOS=linux {{ end }}go build -o main cmd/api/main.go

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -50,7 +50,7 @@ tailwind-install:
 build:{{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }} tailwind-install{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- end }}
 	@echo "Building..."
 	{{ if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}@templ generate{{- end }}
-	{{ if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }}@{{ if .OSCheck.UnixBased }}./tailwindcss{{ else }}.\tailwindcss.exe{{ end }} -i cmd/web/assets/css/input.css -o cmd/web/assets/css/output.css{{ end }}
+	{{ if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }}@{{ if .OSCheck.UnixBased }}./tailwindcss{{ else }}.\tailwindcss.exe{{ end }} -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css{{ end }}
 	{{ if .OSCheck.UnixBased }}@{{- if and (.AdvancedOptions.docker) (eq .DBDriver "sqlite") }}CGO_ENABLED=1 GOOS=linux {{ end }}go build -o main cmd/api/main.go{{- else }}@go build -o main.exe cmd/api/main.go{{- end }}
 
 # Run the application

--- a/docs/docs/advanced-flag/docker.md
+++ b/docs/docs/advanced-flag/docker.md
@@ -19,7 +19,7 @@ RUN go install github.com/a-h/templ/cmd/templ@latest && \
     templ generate && \
     curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 -o tailwindcss && \
     chmod +x tailwindcss && \
-    ./tailwindcss -i cmd/web/assets/css/input.css -o cmd/web/assets/css/output.css
+    ./tailwindcss -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css
 
 RUN go build -o main cmd/api/main.go
 

--- a/docs/docs/advanced-flag/tailwind.md
+++ b/docs/docs/advanced-flag/tailwind.md
@@ -9,9 +9,10 @@ The project tree would look like this:
 │   ├── api/
 │   │   └── main.go
 │   └── web/
+│       ├── styles/
+│       │   └── input.css
 │       ├── assets/
 │       │   ├── css/
-│       │   │   ├── input.css
 │       │   │   └── output.css
 │       │   └── js/
 │       │       └── htmx.min.js
@@ -24,7 +25,7 @@ The project tree would look like this:
 ├── internal/
 │   └── server/
 │       ├── routes.go
-│       ├── routes_test.go 
+│       ├── routes_test.go
 │       └── server.go
 ├── go.mod
 ├── go.sum
@@ -64,7 +65,7 @@ tailwind-install:
 build: tailwind-install templ-install
 	@echo "Building..."
 	@templ generate
-	@./tailwindcss -i cmd/web/assets/css/input.css -o cmd/web/assets/css/output.css
+	@./tailwindcss -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css
 	@go build -o main cmd/api/main.go
 ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -33,9 +33,10 @@ Here's an overview of the project structure created by Go Blueprint when all opt
 │   ├── api/
 │   │   └── main.go               # Main file for starting the server.
 │   └── web/
+│       ├── styles/               # only for generating css will not be served public
+│       │   └── input.css         # Tailwind input file for compiling output.css with CLI when HTMX is used
 │       ├── assets/
 │       │   ├── css/
-│       │   │   ├── input.css     # Tailwind input file for compiling output.css with CLI when HTMX is used
 │       │   │   └── output.css    # Generated CSS file.
 │       │   └── js/
 │       │       └── htmx.min.js   # HTMX library for dynamic HTML content.
@@ -44,7 +45,7 @@ Here's an overview of the project structure created by Go Blueprint when all opt
 │       ├── efs.go                # Includes assets into compiled binary.
 │       ├── hello.go              # Logic for handling "hello" form.
 │       ├── hello.templ           # Template file for the "hello" endpoint.
-│       └── hello_templ.go        # Generated Go code for the "hello" template. 
+│       └── hello_templ.go        # Generated Go code for the "hello" template.
 ├── frontend/                     # React advanced flag. Excludes HTMX.
 │   ├── node_modules/             # Node dependencies.
 │   ├── public/


### PR DESCRIPTION
## Problem

Closes #328 being /assets/css/input.css being publicly accessible when using tailwind with htmx

## Description of Changes: 

- moved /assets/css/input.css to /styles/input.css this makes it explicit that these are styles and will not be included in assets


## Checklist

- [ x ] I have self-reviewed the changes being requested
- [ x ] I have updated the documentation (check issue ticket #218)
