### PR TITLE
fix: spelling error in comment: 'past' to 'paste'

### DIFF
--- a/cmd/flags/database.go
+++ b/cmd/flags/database.go
@@ -8,7 +8,7 @@ import (
 type Database string
 
 // These are all the current databases supported. If you want to add one, you
-// can simply copy and past a line here. Do not forget to also add it into the
+// can simply copy and paste a line here. Do not forget to also add it into the
 // AllowedDBDrivers slice too!
 const (
 	MySql    Database = "mysql"

--- a/cmd/flags/frameworks.go
+++ b/cmd/flags/frameworks.go
@@ -8,7 +8,7 @@ import (
 type Framework string
 
 // These are all the current frameworks supported. If you want to add one, you
-// can simply copy and past a line here. Do not forget to also add it into the
+// can simply copy and paste a line here. Do not forget to also add it into the
 // AllowedProjectTypes slice too!
 const (
 	Chi             Framework = "chi"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

This pull request addresses a minor issue in the documentation where a comment contained a spelling error, "past" instead of "paste." This small change improves clarity and ensures the comments are professional and understandable.

## Description of Changes: 

- Corrected the spelling in the comment from "past" to "paste."

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
