### PR TITLE
Fix spelling errors in docs

### DIFF
--- a/docs/docs/advanced-flag/docker.md
+++ b/docs/docs/advanced-flag/docker.md
@@ -69,7 +69,7 @@ CMD ["serve", "-s", "/app/dist", "-l", "5173"]
 Docker and docker-compose.yml pull environment variables from the .env file.
 
 Example if the Docker flag is used with the MySQL DB driver:
-```ymal
+```yaml
 services:
   app:
     build:

--- a/docs/docs/advanced-flag/react-vite.md
+++ b/docs/docs/advanced-flag/react-vite.md
@@ -77,7 +77,7 @@ After running this command, you can verify the connection between the frontend a
 
 ## Dockerfile
 
-Combine React advanced flag wiht Docker flag to get Docker and docker-compose configuration and run them with:
+Combine React advanced flag with Docker flag to get Docker and docker-compose configuration and run them with:
 
 ```bash
 make docker-run

--- a/docs/docs/endpoints-test/scylladb.md
+++ b/docs/docs/endpoints-test/scylladb.md
@@ -63,7 +63,7 @@ sysctl --write fs.aio-max-nr=1048576
 
 Here's some links for more relevant information and automation:
 
-* [Repository: gvieira/ws-scylla](https://github.com/gvieira18/ws-scylla/) - Simple ScyllaDB Cluster magement with
+* [Repository: gvieira/ws-scylla](https://github.com/gvieira18/ws-scylla/) - Simple ScyllaDB Cluster management with
   Makefiles
 * [ScyllaDB University: 101 Essentials Track](https://university.scylladb.com/courses/scylla-essentials-overview) -
   Learn the base concepts of ScyllaDB


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

This pull request addresses minor issues in the documentation where words contain spelling errors.

## Description of Changes: 

- Correct spelling for `yaml`, `with`, `management` words.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
