### PR TITLE
docs: update installation instructions for Zsh users

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ go install github.com/melkeydev/go-blueprint@latest
 
 This installs a go binary that will automatically bind to your $GOPATH
 
-if you using zsh, you should add manualy at `~/.zshrc`
+> if you’re using Zsh, you’ll need to add it manually to `~/.zshrc`.
 
 ```bash
 GOPATH=$HOME/go  PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
 ```
 
-dont forget to update
+don't forget to update
 
 ```bash
 source ~/.zshrc

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ go install github.com/melkeydev/go-blueprint@latest
 
 This installs a go binary that will automatically bind to your $GOPATH
 
+if you using zsh, you should add manualy at `~/.zshrc`
+
+```bash
+GOPATH=$HOME/go  PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+```
+
+dont forget to update
+
+```bash
+source ~/.zshrc
+```
+
 Then in a new terminal run:
 
 ```bash

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -2,6 +2,7 @@
 hide:
   - toc
 ---
+
 Go-Blueprint provides a convenient CLI tool to effortlessly set up your Go projects. Follow the steps below to install the tool on your system.
 
 ## Binary Installation
@@ -14,6 +15,26 @@ go install github.com/melkeydev/go-blueprint@latest
 
 This command installs the Go-Blueprint binary, automatically binding it to your `$GOPATH`.
 
+> if you’re using Zsh, you’ll need to add it manually to `~/.zshrc`.
+
+> After running the installation command, you need to update your `PATH` environment variable. To do this, you need to find out the correct `GOPATH` for your system. You can do this by running the following command:
+> Check your `GOPATH`
+>
+> ```
+> go env GOPATH
+> ```
+>
+> Then, add the following line to your `~/.zshrc` file:
+>
+> ```
+> GOPATH=$HOME/go  PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+> ```
+>
+> Save the changes to your `~/.zshrc` file by running the following command:
+>
+> ```
+> source ~/.zshrc
+> ```
 
 ## Building and Installing from Source
 
@@ -24,12 +45,13 @@ Clone the Go-Blueprint repository from GitHub:
 ```sh
 git clone https://github.com/melkeydev/go-blueprint
 ```
-   
+
 Build the Go-Blueprint binary:
 
 ```sh
 go build
 ```
+
 Install in your `$PATH` to make it accessible system-wide:
 
 ```sh


### PR DESCRIPTION
## Description of Changes: 

taken from @susilodev pr #347
- a quick extra step to tweak .zshrc during installation for a more straightforward setup
- as @Ujstor suggested updated the docs to make it clear for zsh users

Docs Preview:
![image](https://github.com/user-attachments/assets/4c3ac697-a8c1-491a-862d-9731a0a62a45)



## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
