### PR TITLE
Add coverage in template and add docs

### DIFF
--- a/cmd/template/framework/files/README.md.tmpl
+++ b/cmd/template/framework/files/README.md.tmpl
@@ -50,6 +50,11 @@ Run the test suite:
 make test
 ```
 
+Run the test suite and get coverage report in the browser:
+```bash
+make coverage
+```
+
 Clean up binary from the last build:
 ```bash
 make clean

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -96,6 +96,12 @@ test:
 	@echo "Testing..."
 	@go test ./... -v
 
+# Get tests coverage
+coverage:
+	@echo "Calculating test coverage..."
+	@go test ./... -coverprofile=coverage.out
+	@go tool cover -html=coverage.out
+
 {{- if and (ne .DBDriver "none") (ne .DBDriver "sqlite") }}
 # Integrations Tests for the application
 itest:
@@ -138,4 +144,4 @@ watch:
 	}"
 {{- end }}
 
-.PHONY: all build run test clean watch{{- if and (not .AdvancedOptions.react) .AdvancedOptions.tailwind }} tailwind-install{{- end }}{{- if and (ne .DBDriver "none") (ne .DBDriver "sqlite") }} docker-run docker-down itest{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- end }}
+.PHONY: all build run test coverage clean watch{{- if and (not .AdvancedOptions.react) .AdvancedOptions.tailwind }} tailwind-install{{- end }}{{- if and (ne .DBDriver "none") (ne .DBDriver "sqlite") }} docker-run docker-down itest{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- end }}

--- a/docs/docs/creating-project/makefile.md
+++ b/docs/docs/creating-project/makefile.md
@@ -45,6 +45,10 @@ These targets manage a database container:
 
 Runs unit tests for the application using `go test`.
 
+***`coverage`***
+
+Runs unit tests for the application using `go test` and open browser showing code coverage.
+
 ***`itest`***
 
 Runs integration tests if a database Lite) is used.


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

One feature that I use often is to test based in coverage, but today there is not a way to get this in the Makefile template.

With this in mind, this pull request adds a new make command to get coverage target in Makefile template which was previously missing.

## Description of Changes: 

- Added new coverage make target to generate and display test coverage report
- Updated README.md with instructions for running coverage report
- Added coverage documentation in the makefile documentation
- Updated .PHONY to include the new coverage target

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
