### PR TITLE
fix: return type for postgres tests template

### DIFF
--- a/cmd/template/dbdriver/files/tests/postgres.tmpl
+++ b/cmd/template/dbdriver/files/tests/postgres.tmpl
@@ -11,7 +11,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-func mustStartPostgresContainer() (func(context.Context) error, error) {
+func mustStartPostgresContainer() (func(context.Context, ...testcontainers.TerminateOption) error, error) {
 	var (
 		dbName = "database"
 		dbPwd  = "password"

--- a/contributors.yml
+++ b/contributors.yml
@@ -60,3 +60,4 @@
 - MatthewAraujo
 - mikelerch
 - MohammadAlhallaq
+- silaselisha


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Postgres mustStartPostgresContainer expects to return a function of type func(ctx context.Context, opts ...testcontainers.TerminateOption) error but func(context.Context) error is returned.

## Description of Changes: 

- Wrong type is returned for postgres test, hence changed the postgres template configuration to ensure that the right type is returned when generating postgres test file.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated postgres.tmpl (check issue ticket #363)
