### PR TITLE
avoid allocations by using mirror functions

### DIFF
--- a/cmd/ui/textinput/textinput.go
+++ b/cmd/ui/textinput/textinput.go
@@ -45,7 +45,7 @@ type model struct {
 
 // sanitizeInput verifies that an input text string gets validated
 func sanitizeInput(input string) error {
-	matched, err := regexp.Match("^[a-zA-Z0-9_\\/.-]+$", []byte(input))
+	matched, err := regexp.MatchString("^[a-zA-Z0-9_\\/.-]+$", input)
 	if !matched {
 		return fmt.Errorf("string violates the input regex pattern, err: %v", err)
 	}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -138,7 +138,7 @@ func CheckGitConfig(key string) (bool, error) {
 // ValidateModuleName returns true if it's a valid module name.
 // It allows any number of / and . characters in between.
 func ValidateModuleName(moduleName string) bool {
-	matched, _ := regexp.Match("^[a-zA-Z0-9_-]+(?:[\\/.][a-zA-Z0-9_-]+)*$", []byte(moduleName))
+	matched, _ := regexp.MatchString("^[a-zA-Z0-9_-]+(?:[\\/.][a-zA-Z0-9_-]+)*$", moduleName)
 	return matched
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The PR refactors code to use `regexp.MatchString` to avoid one allocation when converting byte slice to string.

## Description of Changes: 

- Replace `regexp.Match(s, []byte(input))` with `regexp.MatchString(s, input)` where `input` is `string`.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)

## Additional info

This was found with the help of [`mirror`](https://golangci-lint.run/usage/linters/#mirror) linter, which can be enabled in golangci-lint config.