### PR TITLE
Fully integration of Templ live reload with Air

### DIFF
--- a/cmd/template/framework/files/air.toml.tmpl
+++ b/cmd/template/framework/files/air.toml.tmpl
@@ -5,11 +5,11 @@ tmp_dir = "tmp"
 [build]
   args_bin = []
   bin = {{if .OSCheck.UnixBased }}"./main"{{ else }}".\\main.exe"{{ end }}
-  cmd = "make build"
-  delay = 1000
+  cmd = {{if .AdvancedOptions.htmx}}"go build -o main{{if not .OSCheck.UnixBased}}.exe{{end}} cmd/api/main.go"{{else}}"make build"{{end}}
+  delay = 100
   exclude_dir = ["assets", "tmp", "vendor", "testdata", "node_modules"]
   exclude_file = []
-  exclude_regex = ["_test.go"{{if .AdvancedOptions.htmx}}, ".*_templ.go"{{end}}]
+  exclude_regex = ["_test.go"{{if .AdvancedOptions.htmx}}, "_templ.go"{{end}}]
   exclude_unchanged = false
   follow_symlink = false
   full_bin = ""

--- a/cmd/template/framework/files/gitignore.tmpl
+++ b/cmd/template/framework/files/gitignore.tmpl
@@ -28,8 +28,8 @@ tmp/
 # Project build
 main
 {{- if .AdvancedOptions.htmx }}
-*templ.go
-*templ.txt
+*_templ.go
+*_templ.txt
 {{- end }}
 
 # OS X generated file

--- a/cmd/template/framework/files/gitignore.tmpl
+++ b/cmd/template/framework/files/gitignore.tmpl
@@ -27,13 +27,16 @@ tmp/
 
 # Project build
 main
+{{- if .AdvancedOptions.htmx }}
 *templ.go
+*templ.txt
+{{- end }}
 
 # OS X generated file
 .DS_Store
-{{if ( .AdvancedOptions.tailwind )}}
+{{- if .AdvancedOptions.tailwind }}
 
 # Tailwind CSS
 cmd/web/assets/css/output.css
 tailwindcss
-{{end}}
+{{- end }}

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -45,8 +45,12 @@ templ-install:
 {{- if .OSCheck.UnixBased }}
 
 tailwind-install:
-	{{ if .OSCheck.linux }}@if [ ! -f tailwindcss ]; then curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 -o tailwindcss; fi{{- end }}
-	{{ if .OSCheck.darwin }}@if [ ! -f tailwindcss ]; then curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-x64 -o tailwindcss; fi{{- end }}
+{{- if .OSCheck.linux }}
+	@if [ ! -f tailwindcss ]; then curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 -o tailwindcss; fi
+{{- end }}
+{{- if .OSCheck.darwin }}
+	@if [ ! -f tailwindcss ]; then curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-x64 -o tailwindcss; fi
+{{- end }}
 	@chmod +x tailwindcss
 {{- else }}
 
@@ -56,9 +60,12 @@ tailwind-install:
 
 build:{{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }} tailwind-install{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- end }}
 	@echo "Building..."
-	{{ if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}@templ generate{{- end }}
-	{{ if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }}@{{ if .OSCheck.UnixBased }}./tailwindcss{{ else }}.\tailwindcss.exe{{ end }} -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css{{ end }}
-	{{ if .OSCheck.UnixBased }}@{{- if and (.AdvancedOptions.docker) (eq .DBDriver "sqlite") }}CGO_ENABLED=1 GOOS=linux {{ end }}go build -o main cmd/api/main.go{{- else }}@go build -o main.exe cmd/api/main.go{{- end }}
+{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
+	@templ generate
+{{- end }}
+{{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }}
+	@{{- if .OSCheck.UnixBased }}./tailwindcss{{- else }}.\tailwindcss.exe{{- end }} -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css{{- end }}
+	@{{- if .OSCheck.UnixBased }}{{- if and (.AdvancedOptions.docker) (eq .DBDriver "sqlite") }}CGO_ENABLED=1 GOOS=linux {{- end }}go build -o main cmd/api/main.go{{- else }}go build -o main.exe cmd/api/main.go{{- end }}
 
 # Run the application
 run:

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -1,10 +1,13 @@
 # Simple Makefile for a Go project
+{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
+include .env
+{{- end }}
 
 # Build the application
 all: build test
-
 {{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
 {{- if .OSCheck.UnixBased }}
+
 templ-install:
 	@if ! command -v templ > /dev/null; then \
 		read -p "Go's 'templ' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
@@ -20,6 +23,7 @@ templ-install:
 		fi; \
 	fi
 {{- else }}
+
 templ-install:
 	@powershell -ExecutionPolicy Bypass -Command "if (Get-Command templ -ErrorAction SilentlyContinue) { \
 		; \
@@ -35,14 +39,15 @@ templ-install:
 	}"
 {{- end }}
 {{- end }}
-
 {{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }}
 {{- if .OSCheck.UnixBased}}
+
 tailwind-install:
 	{{ if .OSCheck.linux }}@if [ ! -f tailwindcss ]; then curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 -o tailwindcss; fi{{- end }}
 	{{ if .OSCheck.darwin }}@if [ ! -f tailwindcss ]; then curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-macos-x64 -o tailwindcss; fi{{- end }}
 	@chmod +x tailwindcss
 {{- else }}
+
 tailwind-install:
 	@if not exist tailwindcss.exe powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-windows-x64.exe' -OutFile 'tailwindcss.exe'"{{- end }}
 {{- end }}
@@ -60,9 +65,9 @@ run:
 	@npm run dev --prefix ./frontend
 	{{- end }}
 
-
 {{- if or .AdvancedOptions.docker (and (ne .DBDriver "none") (ne .DBDriver "sqlite")) }}
 {{- if .OSCheck.UnixBased }}
+
 # Create DB container
 docker-run:
 	@if docker compose up --build 2>/dev/null; then \
@@ -97,6 +102,7 @@ test:
 	@go test ./... -v
 
 {{- if and (ne .DBDriver "none") (ne .DBDriver "sqlite") }}
+
 # Integrations Tests for the application
 itest:
 	@echo "Running integration tests..."
@@ -109,8 +115,14 @@ clean:
 	@rm -f main
 
 # Live Reload
-{{- if .OSCheck.UnixBased }}
 watch:
+{{- if .OSCheck.UnixBased }}
+{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
+{{- if not .AdvancedOptions.tailwind }}
+	@$(MAKE) -j2 watch/air watch/templ
+{{- end }}
+
+watch/air:
 	@if command -v air > /dev/null; then \
             air; \
             echo "Watching...";\
@@ -125,8 +137,27 @@ watch:
                 exit 1; \
             fi; \
         fi
+
+watch/templ: templ-install
+	@templ generate --watch --proxy="http://localhost:${PORT}" \
+		--proxyport="8000" --open-browser=false -v
 {{- else }}
-watch:
+	@if command -v air > /dev/null; then \
+            air; \
+            echo "Watching...";\
+        else \
+            read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
+            if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
+                go install github.com/air-verse/air@latest; \
+                air; \
+                echo "Watching...";\
+            else \
+                echo "You chose not to install air. Exiting..."; \
+                exit 1; \
+            fi; \
+        fi
+{{- end }}
+{{- else }}
 	@powershell -ExecutionPolicy Bypass -Command "if (Get-Command air -ErrorAction SilentlyContinue) { \
 		air; \
 		Write-Output 'Watching...'; \
@@ -138,4 +169,4 @@ watch:
 	}"
 {{- end }}
 
-.PHONY: all build run test clean watch{{- if and (not .AdvancedOptions.react) .AdvancedOptions.tailwind }} tailwind-install{{- end }}{{- if and (ne .DBDriver "none") (ne .DBDriver "sqlite") }} docker-run docker-down itest{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- end }}
+.PHONY: all build run test clean watch{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} watch/templ watch/air{{- if .AdvancedOptions.tailwind}} watch/tailwind{{- end }}{{- end }}{{- if and (ne .DBDriver "none") (ne .DBDriver "sqlite") }} docker-run docker-down itest{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- if .AdvancedOptions.tailwind }} tailwind-install{{- end }}{{- end }}

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -8,9 +8,9 @@ PROXY_PORT := 8000
 # Build the application
 all: build test
 {{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
-{{- if .OSCheck.UnixBased }}
 
 templ-install:
+{{- if .OSCheck.UnixBased }}
 	@if ! command -v templ > /dev/null; then \
 		read -p "Go's 'templ' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
 		if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
@@ -25,8 +25,6 @@ templ-install:
 		fi; \
 	fi
 {{- else }}
-
-templ-install:
 	@powershell -ExecutionPolicy Bypass -Command "if (Get-Command templ -ErrorAction SilentlyContinue) { \
 		; \
 	} else { \
@@ -42,9 +40,9 @@ templ-install:
 {{- end }}
 {{- end }}
 {{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }}
-{{- if .OSCheck.UnixBased }}
 
 tailwind-install:
+{{- if .OSCheck.UnixBased }}
 {{- if .OSCheck.linux }}
 	@if [ ! -f tailwindcss ]; then curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 -o tailwindcss; fi
 {{- end }}
@@ -53,12 +51,10 @@ tailwind-install:
 {{- end }}
 	@chmod +x tailwindcss
 {{- else }}
-
-tailwind-install:
 	@if not exist tailwindcss.exe powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-windows-x64.exe' -OutFile 'tailwindcss.exe'"{{- end }}
 {{- end }}
 
-build:{{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }} tailwind-install{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- end }}
+build:{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- if .AdvancedOptions.tailwind }} tailwind-install{{- end }}{{- end }}
 	@echo "Building..."
 {{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
 	@templ generate
@@ -124,55 +120,26 @@ clean:
 	@rm -f main
 
 # Live Reload
-watch:
-{{- if .OSCheck.UnixBased }}
 {{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
-{{- if .AdvancedOptions.tailwind }}
-	@$(MAKE) -j3 watch/tailwind watch/air watch/templ
-{{- else }}
-	@$(MAKE) -j2 watch/air watch/templ
-{{- end }}
-
 watch/air:
-	@if command -v air > /dev/null; then \
-            air; \
-            echo "Watching...";\
-        else \
-            read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
-            if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-                go install github.com/air-verse/air@latest; \
-                air; \
-                echo "Watching...";\
-            else \
-                echo "You chose not to install air. Exiting..."; \
-                exit 1; \
-            fi; \
-        fi
-
-watch/templ: templ-install
-	@templ generate --watch --proxy="http://localhost:${PORT}" \
-		--proxyport=$(PROXY_PORT) --open-browser=false -v
-{{- if .AdvancedOptions.tailwind }}
-
-watch/tailwind: tailwind-install
-	@tailwindcss -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css --watch
-{{- end }}
 {{- else }}
-	@if command -v air > /dev/null; then \
-            air; \
-            echo "Watching...";\
-        else \
-            read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
-            if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
-                go install github.com/air-verse/air@latest; \
-                air; \
-                echo "Watching...";\
-            else \
-                echo "You chose not to install air. Exiting..."; \
-                exit 1; \
-            fi; \
-        fi
+watch:
 {{- end }}
+{{- if .OSCheck.UnixBased }}
+	@if command -v air > /dev/null; then \
+		air; \
+		echo "Watching...";\
+	else \
+		read -p "Go's 'air' is not installed on your machine. Do you want to install it? [Y/n] " choice; \
+		if [ "$$choice" != "n" ] && [ "$$choice" != "N" ]; then \
+			go install github.com/air-verse/air@latest; \
+			air; \
+			echo "Watching...";\
+		else \
+			echo "You chose not to install air. Exiting..."; \
+			exit 1; \
+		fi; \
+	fi
 {{- else }}
 	@powershell -ExecutionPolicy Bypass -Command "if (Get-Command air -ErrorAction SilentlyContinue) { \
 		air; \
@@ -184,5 +151,23 @@ watch/tailwind: tailwind-install
 		Write-Output 'Watching...'; \
 	}"
 {{- end }}
+{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
 
-.PHONY: all build run test clean watch{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} watch/templ watch/air{{- if .AdvancedOptions.tailwind}} watch/tailwind{{- end }}{{- end }}{{- if and (ne .DBDriver "none") (ne .DBDriver "sqlite") }} docker-run docker-down itest{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- if .AdvancedOptions.tailwind }} tailwind-install{{- end }}{{- end }}
+watch/templ: templ-install
+	@templ generate --watch --proxy="http://localhost:${PORT}" \
+		--proxyport=$(PROXY_PORT) --open-browser=false -v
+{{- if .AdvancedOptions.tailwind }}
+
+watch/tailwind: tailwind-install
+	@{{- if .OSCheck.UnixBased }}./tailwindcss{{- else }}.\tailwindcss.exe{{- end }} -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css --watch
+{{- end }}
+
+watch:
+{{- if .AdvancedOptions.tailwind }}
+	@$(MAKE) -j3 watch/tailwind watch/templ watch/air
+{{- else }}
+	@$(MAKE) -j2 watch/templ watch/air
+{{- end }}
+{{- end }}
+
+.PHONY: all build run test clean watch{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} watch/air watch/templ{{- if .AdvancedOptions.tailwind}} watch/tailwind{{- end }}{{- end }}{{- if and (ne .DBDriver "none") (ne .DBDriver "sqlite") }} docker-run docker-down itest{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- if .AdvancedOptions.tailwind }} tailwind-install{{- end }}{{- end }}

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -1,6 +1,8 @@
 # Simple Makefile for a Go project
 {{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
 include .env
+
+PROXY_PORT := 8000
 {{- end }}
 
 # Build the application
@@ -40,7 +42,7 @@ templ-install:
 {{- end }}
 {{- end }}
 {{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }}
-{{- if .OSCheck.UnixBased}}
+{{- if .OSCheck.UnixBased }}
 
 tailwind-install:
 	{{ if .OSCheck.linux }}@if [ ! -f tailwindcss ]; then curl -sL https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 -o tailwindcss; fi{{- end }}
@@ -118,7 +120,9 @@ clean:
 watch:
 {{- if .OSCheck.UnixBased }}
 {{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}
-{{- if not .AdvancedOptions.tailwind }}
+{{- if .AdvancedOptions.tailwind }}
+	@$(MAKE) -j3 watch/tailwind watch/air watch/templ
+{{- else }}
 	@$(MAKE) -j2 watch/air watch/templ
 {{- end }}
 
@@ -140,7 +144,12 @@ watch/air:
 
 watch/templ: templ-install
 	@templ generate --watch --proxy="http://localhost:${PORT}" \
-		--proxyport="8000" --open-browser=false -v
+		--proxyport=$(PROXY_PORT) --open-browser=false -v
+{{- if .AdvancedOptions.tailwind }}
+
+watch/tailwind: tailwind-install
+	@tailwindcss -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css --watch
+{{- end }}
 {{- else }}
 	@if command -v air > /dev/null; then \
             air; \

--- a/docs/docs/creating-project/makefile.md
+++ b/docs/docs/creating-project/makefile.md
@@ -53,10 +53,29 @@ Runs integration tests if a database Lite) is used.
 
 Removes the compiled binary (`main` or `main.exe` depending on the OS).
 
-***`watch`***
+***`watch`*** and ***`watch/air`***
+
+This rule will behave in 2 different ways depending whether `templ` is being used or not.
+
+If `templ` is being used, `watch` starts the live reloading, in parallel, for `air`, `templ`, and `tailwindcss` (if selected).
+
+In the case of `templ` not being used, `watch` will behave the same as `watch/air`, which is described below.
 
 Enables live reload for the project using the `air` tool:
 
 - **Unix-based systems**: Checks if `air` is installed and prompts for installation if missing.
 - **Windows**: Uses PowerShell to manage `air` installation and execution.
 
+***`watch/templ`***
+
+Enables `templ` live reload, making a proxy of the `air` one on the port 8000. This provides faster reloading and removes the necessity of manual reloads (`F5` or `Ctrl + R`):
+
+- **Unix-based systems**: Checks if `templ` is installed and prompts for installation if missing.
+- **Windows**: Uses PowerShell to manage `templ` installation and execution.
+
+***`watch/tailwind`***
+
+Enables `tailwindcss` live reload by notifying the `templ` proxy on changes, which will automatically trigger a page reload with the new styles:
+
+- **Unix-based systems**: Checks if `tailwindcss` is installed and installs it if missing.
+- **Windows**: Uses PowerShell to manage `tailwindcss` installation and execution.


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Feature

Templ live reloading fully integrated with Air and TailwindCSS.

## Description of Changes:

This fully integrates Templ live reload with Air. Now it's not necessary to manually reload the page after a change, rebuilds and reloads faster, and also integrates with TailwindCSS live reload.

Solves #368.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)

## Question

Do I need to use `make deploy` on the docs?
