### PR TITLE
Fix `itest` SQLite exception description

### DIFF
--- a/docs/docs/creating-project/makefile.md
+++ b/docs/docs/creating-project/makefile.md
@@ -47,7 +47,7 @@ Runs unit tests for the application using `go test`.
 
 ***`itest`***
 
-Runs integration tests if a database Lite) is used.
+Runs integration tests if a database, with the exception of SQLite, is used.
 
 ***`clean`***
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem

The description of `itest` Make rule not being created when the driver selected is SQLite was cut.

## Description of Changes: 

Add the description that was lacking.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
