### PR TITLE
Improve [Database] Initialize MYSQL Connection

### DIFF
--- a/cmd/template/dbdriver/files/service/mysql.tmpl
+++ b/cmd/template/dbdriver/files/service/mysql.tmpl
@@ -57,6 +57,17 @@ func New() Service {
 	dbInstance = &service{
 		db: db,
 	}
+
+	// Set a timeout for the Ping operation.
+	//
+	// TODO (H0llyW00dzZ): Use an environment variable to customize the timeout (e.g., "10*time.Second").
+	// For now, explicitly setting it to 10 seconds should be sufficient, as it is only used during initialization to avoid runtime confusion.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err = db.PingContext(ctx); err != nil {
+		log.Fatalf("Failed to connect database: %v", err)
+	}
 	return dbInstance
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

This pull request addresses the need to avoid runtime confusion during MySQL connection initialization by adding a timeout to the Ping operation. Without a timeout, the application could hang indefinitely if the database is unreachable, leading to potential issues in production environments.

## Description of Changes: 

- [+] feat(mysql.tmpl): add timeout for the Ping operation during database initialization

## Checklist

- [X] I have self-reviewed the changes being requested
- [X] I have updated the documentation (check issue ticket #218)
