### PR TITLE
Fixed minor interrupt signal bug

### DIFF
--- a/cmd/template/framework/files/main/fiber_main.go.tmpl
+++ b/cmd/template/framework/files/main/fiber_main.go.tmpl
@@ -23,6 +23,7 @@ func gracefulShutdown(fiberServer *server.FiberServer, done chan bool) {
 	<-ctx.Done()
 
 	log.Println("shutting down gracefully, press Ctrl+C again to force")
+	stop() // Allow Ctrl+C to force shutdown
 
 	// The context is used to inform the server it has 5 seconds to finish
 	// the request it is currently handling

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -21,6 +21,7 @@ func gracefulShutdown(apiServer *http.Server, done chan bool) {
 	<-ctx.Done()
 
 	log.Println("shutting down gracefully, press Ctrl+C again to force")
+	stop() // Allow Ctrl+C to force shutdown
 
 	// The context is used to inform the server it has 5 seconds to finish
 	// the request it is currently handling


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

The code prints a message stating that you can press `Ctrl+C` again to force the shutdown, but this doesn't actually work because the signal listener is stopped in a deferred function call which doesn't run until after the graceful shutdown is complete.

One way to verify this is to add a very slow handler (eg use a `time.Sleep`), visit that page, then press `Ctrl+C` multiple times to try to force the shutdown.

## Description of Changes: 

- Call `stop()` immediately after receiving an interrupt signal to unregister our behavior and revert to default behavior.
- Opted to leave the `defer stop()` call since it doesn't matter if we call it twice. It could be removed, but I tend to leave it to avoid future bugs.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
