### PR TITLE
more transparent error message when error executing command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -273,7 +273,7 @@ var createCmd = &cobra.Command{
 			if releaseErr := spinner.ReleaseTerminal(); releaseErr != nil {
 				log.Printf("Problem releasing terminal: %v", releaseErr)
 			}
-			log.Printf("Problem creating files for project. %v", err)
+			log.Printf("Problem creating files for project.")
 			cobra.CheckErr(textinput.CreateErrorInputModel(err).Err())
 		}
 

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -293,7 +293,7 @@ func (p *Project) CreateMainFile() error {
 	if p.ProjectType != flags.StandardLibrary {
 		err = utils.GoGetPackage(projectPath, p.FrameworkMap[p.ProjectType].packageName)
 		if err != nil {
-			log.Printf("Could not install go dependency for the chosen framework %v\n", err)
+			log.Println("Could not install go dependency for the chosen framework")
 			return err
 		}
 	}
@@ -303,7 +303,7 @@ func (p *Project) CreateMainFile() error {
 		p.createDBDriverMap()
 		err = utils.GoGetPackage(projectPath, p.DBDriverMap[p.DBDriver].packageName)
 		if err != nil {
-			log.Printf("Could not install go dependency for chosen driver %v\n", err)
+			log.Println("Could not install go dependency for chosen driver")
 			return err
 		}
 
@@ -348,7 +348,7 @@ func (p *Project) CreateMainFile() error {
 	err = utils.GoGetPackage(projectPath, godotenvPackage)
 
 	if err != nil {
-		log.Printf("Could not install go dependency %v\n", err)
+		log.Println("Could not install go dependency")
 
 		return err
 	}
@@ -529,7 +529,7 @@ func (p *Project) CreateMainFile() error {
 		}
 		err = utils.GoGetPackage(projectPath, templPackage)
 		if err != nil {
-			log.Printf("Could not install go dependency %v\n", err)
+			log.Println("Could not install go dependency")
 			return err
 		}
 
@@ -547,7 +547,7 @@ func (p *Project) CreateMainFile() error {
 			}
 			err = utils.GoGetPackage(projectPath, []string{"github.com/gofiber/fiber/v2/middleware/adaptor"})
 			if err != nil {
-				log.Printf("Could not install go dependency %v\n", err)
+				log.Println("Could not install go dependency")
 				return err
 			}
 		} else {

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -52,9 +52,11 @@ func ExecuteCmd(name string, args []string, dir string) error {
 	command := exec.Command(name, args...)
 	command.Dir = dir
 	var out bytes.Buffer
+	var stdErr bytes.Buffer
 	command.Stdout = &out
+	command.Stderr = &stdErr
 	if err := command.Run(); err != nil {
-		return err
+		return fmt.Errorf("%v\n%v", err, stdErr.String())
 	}
 	return nil
 }


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Currently when there is error on executing command it doesn't tell what the problem is and may cause confusion like #379 .
This PR aim to present more transparent error message that will for example looks like:
```shell
2025/03/13 10:15:47 Could not install go dependency for the chosen framework
2025/03/13 10:15:47 Problem creating files for project.
Error: exit status 1
go: golang.org/x/sys@v0.31.0 requires go >= 1.23.0 (running go 1.22.2)
go: golang.org/x/sys@v0.31.0 requires go >= 1.23.0 (running go 1.22.2)
go: golang.org/x/sys@v0.31.0 requires go >= 1.23.0 (running go 1.22.2)
go: golang.org/x/sys@v0.31.0 requires go >= 1.23.0 (running go 1.22.2)

```

## Description of Changes: 

- Change the way error message presented

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
