### PR TITLE
fix: dont install less than v4 tailwindcss

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -346,7 +346,6 @@ func (p *Project) CreateMainFile() error {
 
 	// Install the godotenv package
 	err = utils.GoGetPackage(projectPath, godotenvPackage)
-
 	if err != nil {
 		log.Println("Could not install go dependency")
 
@@ -879,7 +878,7 @@ func (p *Project) CreateViteReactProject(projectPath string) error {
 		cmd := exec.Command("npm", "install",
 			"--prefer-offline",
 			"--no-fund",
-			"tailwindcss", "@tailwindcss/vite")
+			"tailwindcss@^4", "@tailwindcss/vite")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
@@ -918,6 +917,7 @@ func (p *Project) CreateViteReactProject(projectPath string) error {
 
 	return nil
 }
+
 func (p *Project) CreateHtmxTemplates() {
 	routesPlaceHolder := ""
 	importsPlaceHolder := ""


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

As the @tailwindcss/vite is installed and only supports v4 we are using --prefer-offline flag that can install probably install  tailwindcss v3 from cache with this we force to use cache only is tailwindcss version is greater than v4

## Description of Changes: 

Added constraint so it only installs greater than v4 in the cache
"tailwindcss@^4"


## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
