### PR TITLE
feat: add flag completions

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -53,21 +53,10 @@ func init() {
 	createCmd.Flags().Var(&advancedFeatures, "feature", fmt.Sprintf("Advanced feature to use. Allowed values: %s", strings.Join(flags.AllowedAdvancedFeatures, ", ")))
 	createCmd.Flags().VarP(&flagGit, "git", "g", fmt.Sprintf("Git to use. Allowed values: %s", strings.Join(flags.AllowedGitsOptions, ", ")))
 
-	createCmd.RegisterFlagCompletionFunc("framework", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return flags.AllowedProjectTypes, cobra.ShellCompDirectiveNoFileComp
-	})
-
-	createCmd.RegisterFlagCompletionFunc("driver", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return flags.AllowedDBDrivers, cobra.ShellCompDirectiveNoFileComp
-	})
-
-	createCmd.RegisterFlagCompletionFunc("feature", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return flags.AllowedAdvancedFeatures, cobra.ShellCompDirectiveNoFileComp
-	})
-
-	createCmd.RegisterFlagCompletionFunc("git", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return flags.AllowedGitsOptions, cobra.ShellCompDirectiveNoFileComp
-	})
+	utils.RegisterStaticCompletions(createCmd, "framework", flags.AllowedProjectTypes)
+	utils.RegisterStaticCompletions(createCmd, "driver", flags.AllowedDBDrivers)
+	utils.RegisterStaticCompletions(createCmd, "feature", flags.AllowedAdvancedFeatures)
+	utils.RegisterStaticCompletions(createCmd, "git", flags.AllowedGitsOptions)
 }
 
 type Options struct {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -52,6 +52,22 @@ func init() {
 	createCmd.Flags().BoolP("advanced", "a", false, "Get prompts for advanced features")
 	createCmd.Flags().Var(&advancedFeatures, "feature", fmt.Sprintf("Advanced feature to use. Allowed values: %s", strings.Join(flags.AllowedAdvancedFeatures, ", ")))
 	createCmd.Flags().VarP(&flagGit, "git", "g", fmt.Sprintf("Git to use. Allowed values: %s", strings.Join(flags.AllowedGitsOptions, ", ")))
+
+	createCmd.RegisterFlagCompletionFunc("framework", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return flags.AllowedProjectTypes, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	createCmd.RegisterFlagCompletionFunc("driver", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return flags.AllowedDBDrivers, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	createCmd.RegisterFlagCompletionFunc("feature", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return flags.AllowedAdvancedFeatures, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	createCmd.RegisterFlagCompletionFunc("git", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return flags.AllowedGitsOptions, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 type Options struct {

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -5,6 +5,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -49,9 +50,13 @@ func NonInteractiveCommand(use string, flagSet *pflag.FlagSet) string {
 }
 
 func RegisterStaticCompletions(cmd *cobra.Command, flag string, options []string) {
-	cmd.RegisterFlagCompletionFunc(flag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	err := cmd.RegisterFlagCompletionFunc(flag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return options, cobra.ShellCompDirectiveNoFileComp
 	})
+
+	if err != nil {
+		log.Printf("warning: could not register completion for --%s: %v", flag, err)
+	}
 }
 
 // ExecuteCmd provides a shorthand way to run a shell command

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -45,6 +46,12 @@ func NonInteractiveCommand(use string, flagSet *pflag.FlagSet) string {
 	flagSet.VisitAll(visitFn)
 
 	return nonInteractiveCommand
+}
+
+func RegisterStaticCompletions(cmd *cobra.Command, flag string, options []string) {
+	cmd.RegisterFlagCompletionFunc(flag, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return options, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 // ExecuteCmd provides a shorthand way to run a shell command


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Added flag completions 

## Description of Changes: 

- created a function in `cmd/utils/utils.go` that takes a cobra command, a string representing a flag, and an array of strings representing the posible values of the flag
- implemented the completions for advanced flags in `cmd/create/create.go` using the already defined options declared in the different modules


## Checklist

- [x] I have self-reviewed the changes being requested

