### PR TITLE
Fixed no git on system panic even if git flag is skip

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -253,15 +253,17 @@ func (p *Project) CreateMainFile() error {
 	}
 
 	// Check if user.email is set.
-	emailSet, err := utils.CheckGitConfig("user.email")
-	if err != nil {
-		return err
-	}
+	if p.GitOptions.String() != flags.Skip {
 
-	if !emailSet && p.GitOptions.String() != flags.Skip {
-		fmt.Println("user.email is not set in git config.")
-		fmt.Println("Please set up git config before trying again.")
-		panic("\nGIT CONFIG ISSUE: user.email is not set in git config.\n")
+		emailSet, err := utils.CheckGitConfig("user.email")
+		if err != nil {
+			return err
+		}
+		if !emailSet {
+			fmt.Println("user.email is not set in git config.")
+			fmt.Println("Please set up git config before trying again.")
+			panic("\nGIT CONFIG ISSUE: user.email is not set in git config.\n")
+		}
 	}
 
 	p.ProjectName = strings.TrimSpace(p.ProjectName)
@@ -283,7 +285,7 @@ func (p *Project) CreateMainFile() error {
 	p.createFrameworkMap()
 
 	// Create go.mod
-	err = utils.InitGoMod(p.ProjectName, projectPath)
+	err := utils.InitGoMod(p.ProjectName, projectPath)
 	if err != nil {
 		log.Printf("Could not initialize go.mod in new project %v\n", err)
 		return err
@@ -678,12 +680,12 @@ func (p *Project) CreateMainFile() error {
 		return err
 	}
 
-	nameSet, err := utils.CheckGitConfig("user.name")
-	if err != nil {
-		return err
-	}
-
 	if p.GitOptions != flags.Skip {
+		nameSet, err := utils.CheckGitConfig("user.name")
+		if err != nil {
+			return err
+		}
+
 		if !nameSet {
 			fmt.Println("user.name is not set in git config.")
 			fmt.Println("Please set up git config before trying again.")


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Fix for the [[Bug] Panic occurs when there is no git #360](https://github.com/Melkeydev/go-blueprint/issues/360). 
I ran the tests and tested multiple combinations locally.
I saw that it was planned in another refactor PR which has been in progress for a very long time and has a lot of changes. I created this PR to just fix the bug independent of the refactoring.

## Description of Changes: 
Localized the call of `utils.CheckGitConfig` since it is only needed if the git flag is not set to `skip`. 

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218) (no documentation update needed, only a bugfix)
