### PR TITLE
added hot reload proxy for htmx

### DIFF
--- a/cmd/template/framework/files/air.toml.tmpl
+++ b/cmd/template/framework/files/air.toml.tmpl
@@ -44,3 +44,10 @@ tmp_dir = "tmp"
 [screen]
   clear_on_rebuild = false
   keep_scroll = true
+{{- if .AdvancedOptions.htmx}}
+
+[proxy]
+  proxy_port = 3000
+  app_port = 8080
+  enabled = true
+{{- end}}

--- a/docs/docs/creating-project/air.md
+++ b/docs/docs/creating-project/air.md
@@ -27,7 +27,8 @@ watching internal/database
 watching internal/server
 watching tests
 !exclude tmp
-building...
+building..
+Proxy server listening on http://localhost:3000
 make[1]: Entering directory '/home/ujstor/code/blueprint-version-test/ws-test4'
 Building...
 Processing path: /home/ujstor/code/blueprint-version-test/ws-test4

--- a/docs/docs/creating-project/air.md
+++ b/docs/docs/creating-project/air.md
@@ -27,7 +27,7 @@ watching internal/database
 watching internal/server
 watching tests
 !exclude tmp
-building..
+building...
 Proxy server listening on http://localhost:3000
 make[1]: Entering directory '/home/ujstor/code/blueprint-version-test/ws-test4'
 Building...


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Added air proxy for htmx so that the page refreshes when air rebuilds

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
