### PR TITLE
Add tailwind config for Tailwind LSP support in templ files

### DIFF
--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -505,6 +505,18 @@ func (p *Project) CreateMainFile() error {
 			return err
 		}
 
+		htmxTailwindConfigJsFile, err := os.Create(fmt.Sprintf("%s/tailwind.config.js", projectPath))
+		if err != nil {
+			return err
+		}
+		defer htmxTailwindConfigJsFile.Close()
+
+		htmxTailwindConfigJsTemplate := advanced.HtmxTailwindConfigJsTemplate()
+		err = os.WriteFile(fmt.Sprintf("%s/tailwind.config.js", projectPath), htmxTailwindConfigJsTemplate, 0o644)
+		if err != nil {
+			return err
+		}
+
 		efsFile, err := os.Create(fmt.Sprintf("%s/%s/efs.go", projectPath, cmdWebPath))
 		if err != nil {
 			return err

--- a/cmd/template/advanced/files/htmx/tailwind/tailwind.config.js.tmpl
+++ b/cmd/template/advanced/files/htmx/tailwind/tailwind.config.js.tmpl
@@ -1,0 +1,5 @@
+module.exports = {
+	content: ["./**/*.html", "./**/*.templ", "./**/*.go",],
+	theme: { extend: {}, },
+	plugins: [],
+}

--- a/cmd/template/advanced/routes.go
+++ b/cmd/template/advanced/routes.go
@@ -28,6 +28,9 @@ var inputCssTemplate []byte
 //go:embed files/tailwind/output.css.tmpl
 var outputCssTemplate []byte
 
+//go:embed files/htmx/tailwind/tailwind.config.js.tmpl
+var htmxTailwindConfigJsTemplate []byte
+
 //go:embed files/htmx/htmx.min.js.tmpl
 var htmxMinJsTemplate []byte
 
@@ -138,6 +141,10 @@ func InputCssTemplate() []byte {
 
 func OutputCssTemplate() []byte {
 	return outputCssTemplate
+}
+
+func HtmxTailwindConfigJsTemplate() []byte {
+	return htmxTailwindConfigJsTemplate
 }
 
 func HtmxJSTemplate() []byte {


### PR DESCRIPTION
## Problem/Feature

When making a Tailwind template which uses HTMX by default, there isn't any config file that signals that the LSP should be active on templ files, which means that you have to manually add it. This change aims to fix that, though I'm not sure if this change is needed when making other templates using Tailwind too, if so, I'm willing to update this PR to change those as well.

## Description of Changes: 

- added a new `cmd/template/advanced/files/htmx/tailwind` folder and a `cmd/template/advanced/files/htmx/tailwind/tailwind.config.js.tmpl` file
- added the `tailwind.config.js.tmpl` file to `cmd/templates/advanced/routes.go`
- added the file to `program.go`

## Checklist

- [x] I have self-reviewed the changes being requested
