### PR TITLE
Release to NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,88 @@
+name: npm-publish
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., v1.0.0)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., v1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+      
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Download release assets
+        run: |
+          set -euo pipefail
+          
+          TAG="${{ inputs.tag }}"
+          VERSION=${TAG#v}
+          
+          echo "Downloading assets for version: $VERSION (tag: $TAG)"
+          
+          mkdir -p dist
+          
+          # Download all release assets
+          gh release download "$TAG" --dir dist
+          
+          ls -la dist/
+          
+          # Store the version for next steps
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create npm packages
+        run: |
+          set -euo pipefail
+          
+          echo "Creating npm packages for version: $VERSION"
+          
+          chmod +x ./scripts/create-npm-packages.sh
+          ./scripts/create-npm-packages.sh "$VERSION"
+
+      - name: Publish platform-specific packages to npm
+        run: |
+          set -euo pipefail
+          
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          
+          for platform_dir in platform-packages/go-blueprint-*; do
+            if [ -d "$platform_dir" ]; then
+              echo "Publishing $(basename $platform_dir)..."
+              cd "$platform_dir"
+              npm publish --access public
+              cd - > /dev/null
+            fi
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish main package to npm
+        run: |
+          set -euo pipefail
+          
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          
+          cd npm-package
+          echo "Publishing main go-blueprint package..."
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,8 @@ on:
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
       
       - name: Download release assets
@@ -45,7 +47,6 @@ jobs:
 
       - name: Publish platform-specific packages to npm
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           for platform_dir in platform-packages/go-blueprint-*; do
             if [ -d "$platform_dir" ]; then
               cd "$platform_dir"
@@ -53,13 +54,8 @@ jobs:
               cd - > /dev/null
             fi
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish main package to npm
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           cd npm-package
           npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: NPM Publisher
+name: npm-publish
 
 on:
   workflow_call:
@@ -14,48 +14,38 @@ on:
         required: true
         type: string
 
-env:
-  NODE_VERSION: '22'
-  REGISTRY_URL: 'https://registry.npmjs.org'
-
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code at release tag
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
       
-      - name: Setup Node
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: ${{ env.REGISTRY_URL }}
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
       
-      - name: Extract version and download release assets
+      - name: Download release assets
         run: |
           TAG="${{ inputs.tag }}"
           VERSION=${TAG#v}
-          
           mkdir -p dist
           gh release download "$TAG" --dir dist
-          
           echo "VERSION=$VERSION" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate NPM package structure
+      - name: Create npm packages
         run: |
           chmod +x ./scripts/create-npm-packages.sh
           ./scripts/create-npm-packages.sh "$VERSION"
-          
-      - name: Configure NPM authentication
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
-      - name: Publish platform-specific packages
+      - name: Publish platform-specific packages to npm
         run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           for platform_dir in platform-packages/go-blueprint-*; do
             if [ -d "$platform_dir" ]; then
               cd "$platform_dir"
@@ -63,8 +53,13 @@ jobs:
               cd - > /dev/null
             fi
           done
-          
-      - name: Publish main package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish main package to npm
         run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           cd npm-package
           npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: npm-publish
+name: NPM Publisher
 
 on:
   workflow_call:
@@ -14,75 +14,57 @@ on:
         required: true
         type: string
 
+env:
+  NODE_VERSION: '22'
+  REGISTRY_URL: 'https://registry.npmjs.org'
+
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code at release tag
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
       
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: ${{ env.REGISTRY_URL }}
       
-      - name: Download release assets
+      - name: Extract version and download release assets
         run: |
-          set -euo pipefail
-          
           TAG="${{ inputs.tag }}"
           VERSION=${TAG#v}
           
-          echo "Downloading assets for version: $VERSION (tag: $TAG)"
-          
           mkdir -p dist
-          
-          # Download all release assets
           gh release download "$TAG" --dir dist
           
-          ls -la dist/
-          
-          # Store the version for next steps
           echo "VERSION=$VERSION" >> $GITHUB_ENV
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create npm packages
+      - name: Generate NPM package structure
         run: |
-          set -euo pipefail
-          
-          echo "Creating npm packages for version: $VERSION"
-          
           chmod +x ./scripts/create-npm-packages.sh
           ./scripts/create-npm-packages.sh "$VERSION"
-
-      - name: Publish platform-specific packages to npm
+          
+      - name: Configure NPM authentication
         run: |
-          set -euo pipefail
-          
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Publish platform-specific packages
+        run: |
           for platform_dir in platform-packages/go-blueprint-*; do
             if [ -d "$platform_dir" ]; then
-              echo "Publishing $(basename $platform_dir)..."
               cd "$platform_dir"
               npm publish --access public
               cd - > /dev/null
             fi
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish main package to npm
+          
+      - name: Publish main package
         run: |
-          set -euo pipefail
-          
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          
           cd npm-package
-          echo "Publishing main go-blueprint package..."
           npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,3 +27,10 @@ jobs:
           workdir: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm-publish:
+    needs: goreleaser
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -37,9 +37,14 @@ gives the option to integrate with one of the more popular Go frameworks (and th
   Install
 </h2>
 
+### Go Install
 ```bash
 go install github.com/melkeydev/go-blueprint@latest
 ```
+
+### NPM Install
+```bash
+npm install go-blueprint
 
 This installs a go binary that will automatically bind to your $GOPATH
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ gives the option to integrate with one of the more popular Go frameworks (and th
 go install github.com/melkeydev/go-blueprint@latest
 ```
 
-### NPM Install
-```bash
-npm install go-blueprint
-
 This installs a go binary that will automatically bind to your $GOPATH
 
 > if you’re using Zsh, you’ll need to add it manually to `~/.zshrc`.
@@ -58,6 +54,16 @@ don't forget to update
 
 ```bash
 source ~/.zshrc
+```
+
+### NPM Install
+```bash
+npm install -g go-blueprint
+```
+
+### Homebrew Install
+```bash
+brew install go-blueprint
 ```
 
 Then in a new terminal run:

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -36,6 +36,26 @@ This command installs the Go-Blueprint binary, automatically binding it to your 
 > source ~/.zshrc
 > ```
 
+## NPM Install
+
+If you prefer using Node.js package manager, you can install Go-Blueprint via NPM. This method is convenient for developers who are already working in JavaScript/Node.js environments and want to integrate Go-Blueprint into their existing workflow.
+
+```bash
+npm install -g go-blueprint
+```
+
+The `-g` flag installs Go-Blueprint globally, making it accessible from any directory on your system.
+
+## Homebrew Install
+
+For macOS and Linux users, Homebrew provides a simple way to install Go-Blueprint. Homebrew automatically handles dependencies and keeps the tool updated through its package management system.
+
+```bash
+brew install go-blueprint
+```
+
+After installation via Homebrew, Go-Blueprint will be automatically added to your PATH, making it immediately available in your terminal.
+
 ## Building and Installing from Source
 
 If you prefer to build and install Go-Blueprint directly from the source code, you can follow these steps:

--- a/scripts/create-npm-packages.sh
+++ b/scripts/create-npm-packages.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VERSION="$1"
+PACKAGE_NAME="go-blueprint"
+MAIN_PACKAGE_DIR="npm-package"
+PLATFORM_PACKAGES_DIR="platform-packages"
+
+rm -rf "$MAIN_PACKAGE_DIR" "$PLATFORM_PACKAGES_DIR"
+
+mkdir -p "$MAIN_PACKAGE_DIR/bin" "$PLATFORM_PACKAGES_DIR"
+
+declare -A PLATFORM_MAP=(
+    ["go-blueprint_${VERSION}_Darwin_all"]="darwin-x64,darwin-arm64"
+    ["go-blueprint_${VERSION}_Linux_x86_64"]="linux-x64"
+    ["go-blueprint_${VERSION}_Linux_arm64"]="linux-arm64"
+    ["go-blueprint_${VERSION}_Windows_x86_64"]="win32-x64"
+    ["go-blueprint_${VERSION}_Windows_arm64"]="win32-arm64"
+)
+
+declare -A OS_MAP=(
+    ["darwin-x64"]="darwin"
+    ["darwin-arm64"]="darwin"
+    ["linux-x64"]="linux"
+    ["linux-arm64"]="linux"
+    ["win32-x64"]="win32"
+    ["win32-arm64"]="win32"
+)
+
+declare -A CPU_MAP=(
+    ["darwin-x64"]="x64"
+    ["darwin-arm64"]="arm64"
+    ["linux-x64"]="x64"
+    ["linux-arm64"]="arm64"
+    ["win32-x64"]="x64"
+    ["win32-arm64"]="arm64"
+)
+
+OPTIONAL_DEPS=""
+for archive in dist/*.tar.gz dist/*.zip; do
+    if [ -f "$archive" ]; then
+        archive_name=$(basename "$archive")
+        archive_name="${archive_name%.tar.gz}"
+        archive_name="${archive_name%.zip}"
+        
+        platform_keys="${PLATFORM_MAP[$archive_name]:-}"
+        
+        if [ -n "$platform_keys" ]; then
+            echo "Processing $archive for platforms: $platform_keys"
+            
+            IFS=',' read -ra PLATFORM_ARRAY <<< "$platform_keys"
+            for platform_key in "${PLATFORM_ARRAY[@]}"; do
+                platform_key=$(echo "$platform_key" | xargs)
+                
+                echo "  Creating package for platform: $platform_key"
+                
+                platform_package_dir="$PLATFORM_PACKAGES_DIR/$PACKAGE_NAME-$platform_key"
+                mkdir -p "$platform_package_dir/bin"
+                
+                if [[ "$archive" == *.tar.gz ]]; then
+                    tar -xzf "$archive" -C "$platform_package_dir/bin"
+                else
+                    unzip -j "$archive" -d "$platform_package_dir/bin"
+                fi
+                
+                for doc_file in README.md README README.txt LICENSE LICENSE.md LICENSE.txt; do
+                    if [ -f "$platform_package_dir/bin/$doc_file" ]; then
+                        mv "$platform_package_dir/bin/$doc_file" "$platform_package_dir/"
+                    fi
+                done
+                
+                ls -l "$platform_package_dir/bin"
+                chmod +x "$platform_package_dir/bin/"*
+                
+                os_value="${OS_MAP[$platform_key]}"
+                cpu_value="${CPU_MAP[$platform_key]}"
+                
+                files_array='["bin/"]'
+                for doc_file in README.md README README.txt LICENSE LICENSE.md LICENSE.txt; do
+                    if [ -f "$platform_package_dir/$doc_file" ]; then
+                        files_array="${files_array%]}, \"$doc_file\"]"
+                    fi
+                done
+                
+                binary_name="go-blueprint"
+                if [[ "$os_value" == "win32" ]]; then
+                    binary_name="go-blueprint.exe"
+                fi
+                
+                cat > "$platform_package_dir/package.json" << EOF
+{
+  "name": "$PACKAGE_NAME-$platform_key",
+  "version": "$VERSION",
+  "description": "Platform-specific binary for $PACKAGE_NAME ($platform_key)",
+  "os": ["$os_value"],
+  "cpu": ["$cpu_value"],
+  "bin": {
+    "go-blueprint": "bin/$binary_name"
+  },
+  "files": $files_array,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Melkeydev/go-blueprint.git"
+  },
+  "author": "Melkeydev",
+  "license": "MIT"
+}
+EOF
+                
+                if [ -n "$OPTIONAL_DEPS" ]; then
+                    OPTIONAL_DEPS="$OPTIONAL_DEPS,"
+                fi
+                OPTIONAL_DEPS="$OPTIONAL_DEPS\"$PACKAGE_NAME-$platform_key\": \"$VERSION\""
+            done
+        fi
+    fi
+done
+
+cat > "$MAIN_PACKAGE_DIR/bin/go-blueprint" << 'EOF'
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process')
+
+const packageName = 'go-blueprint'
+
+const platformPackages = {
+  'darwin-x64': `${packageName}-darwin-x64`,
+  'darwin-arm64': `${packageName}-darwin-arm64`,
+  'linux-x64': `${packageName}-linux-x64`,
+  'linux-arm64': `${packageName}-linux-arm64`,
+  'win32-x64': `${packageName}-win32-x64`,
+  'win32-arm64': `${packageName}-win32-arm64`
+}
+
+function getBinaryPath() {
+  const platformKey = `${process.platform}-${process.arch}`
+  const platformPackageName = platformPackages[platformKey]
+
+  if (!platformPackageName) {
+    console.error(`Platform ${platformKey} is not supported!`)
+    process.exit(1)
+  }
+
+  try {
+    const binaryName = process.platform === 'win32' ? 'go-blueprint.exe' : 'go-blueprint'
+    return require.resolve(`${platformPackageName}/bin/${binaryName}`)
+  } catch (e) {
+    process.exit(1)
+  }
+}
+
+try {
+  const binaryPath = getBinaryPath()
+  execFileSync(binaryPath, process.argv.slice(2), { stdio: 'inherit' })
+} catch (error) {
+  console.error('Failed to execute go-blueprint:', error.message)
+  process.exit(1)
+}
+EOF
+
+chmod +x "$MAIN_PACKAGE_DIR/bin/go-blueprint"
+
+cat > "$MAIN_PACKAGE_DIR/package.json" << EOF
+{
+  "name": "$PACKAGE_NAME",
+  "version": "$VERSION",
+  "description": "A CLI for scaffolding Go projects with modern tooling",
+  "main": "index.js",
+  "bin": {
+    "go-blueprint": "bin/go-blueprint"
+  },
+  "optionalDependencies": {
+    $OPTIONAL_DEPS
+  },
+  "keywords": ["go", "golang", "cli"],
+  "author": "Melkeydev",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Melkeydev/go-blueprint.git"
+  },
+  "homepage": "https://github.com/Melkeydev/go-blueprint",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "files": [
+    "bin/",
+    "index.js",
+    "README.md"
+  ]
+}
+EOF
+
+cat > "$MAIN_PACKAGE_DIR/index.js" << 'EOF'
+const { execFileSync } = require('child_process')
+const path = require('path')
+
+const binaryName = process.platform === 'win32' ? 'go-blueprint.exe' : 'go-blueprint'
+
+const packageName = 'go-blueprint'
+
+const platformPackages = {
+  'darwin-x64': `${packageName}-darwin-x64`,
+  'darwin-arm64': `${packageName}-darwin-arm64`,
+  'linux-x64': `${packageName}-linux-x64`,
+  'linux-arm64': `${packageName}-linux-arm64`,
+  'win32-x64': `${packageName}-win32-x64`,
+  'win32-arm64': `${packageName}-win32-arm64`
+}
+
+function getBinaryPath() {
+  const platformKey = `${process.platform}-${process.arch}`
+  const platformPackageName = platformPackages[platformKey]
+
+  if (!platformPackageName) {
+    throw new Error(`Platform ${platformKey} is not supported!`)
+  }
+
+  try {
+    return require.resolve(`${platformPackageName}/bin/${binaryName}`)
+  } catch (e) {
+    throw new Error(`Platform-specific package ${platformPackageName} not found.`)
+  }
+}
+
+module.exports = {
+  getBinaryPath,
+  run: function(...args) {
+    const binaryPath = getBinaryPath()
+    return execFileSync(binaryPath, args, { stdio: 'inherit' })
+  }
+}
+EOF
+
+first_platform_dir=$(ls -1d "$PLATFORM_PACKAGES_DIR"/* | head -1 2>/dev/null || echo "")
+if [ -n "$first_platform_dir" ] && [ -f "$first_platform_dir/README.md" ]; then
+    cp "$first_platform_dir/README.md" "$MAIN_PACKAGE_DIR/"
+fi


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

This is a collaborative PR with @NachoVazquez that address the [Issue-405](https://github.com/Melkeydev/go-blueprint/issues/405). The goal is to provide NPM distribution for the Go-Blueprint library. We are using [optionalDependencies](https://github.com/evanw/esbuild/pull/1621) to handle cross-platform compatibility by deploying separate packages for each OS-architecture combination of the library binaries.


Examples can be found [here](https://www.npmjs.com/package/go-blueprint-test?activeTab=readme).


## Description of Changes: 

- **New workflow for NPM publishing**: Automated publishing process that runs after GoReleaser completion.
- **Build script**: Bash script that generates the platform-specific NPM packages and the main Go-Blueprint installation package.
- **Documentation update**: Updated README with NPM installation instructions.

PS: NPM token secret (**NPM_TOKEN**) must be added to the repository with publishing permissions.

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
