### PR TITLE
ci: add npm provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,32 +4,35 @@ on:
   workflow_call:
     inputs:
       tag:
-        description: 'Release tag to publish (e.g., v1.0.0)'
+        description: "Release tag to publish (e.g., v1.0.0)"
         required: true
         type: string
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to publish (e.g., v1.0.0)'
+        description: "Release tag to publish (e.g., v1.0.0)"
         required: true
         type: string
 
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag }}
-      
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
-      
+          registry-url: "https://registry.npmjs.org"
+
       - name: Download release assets
         run: |
           TAG="${{ inputs.tag }}"
@@ -50,7 +53,7 @@ jobs:
           for platform_dir in platform-packages/go-blueprint-*; do
             if [ -d "$platform_dir" ]; then
               cd "$platform_dir"
-              npm publish --access public
+              npm publish --provenance --access public
               cd - > /dev/null
             fi
           done
@@ -58,4 +61,5 @@ jobs:
       - name: Publish main package to npm
         run: |
           cd npm-package
-          npm publish --access public
+          npm publish --provenance --access public
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.1'
-      -
-        name: Run GoReleaser
+          go-version: "1.21.1"
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5.0.0
         with:
           distribution: goreleaser
@@ -30,7 +29,11 @@ jobs:
 
   npm-publish:
     needs: goreleaser
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/npm-publish.yml
     with:
       tag: ${{ github.ref_name }}
     secrets: inherit
+


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

We are not generating NPM provenance when releasing to NPM.

https://docs.npmjs.com/generating-provenance-statements

## Description of Changes: 

- We added the necessary permissions to generate the npm provenance
- We added the `--provenance` flag to the `npm publish` command

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
