### PR TITLE
Fix the wrong variable name in standard_library.go.tmpl

### DIFF
--- a/cmd/template/framework/files/server/standard_library.go.tmpl
+++ b/cmd/template/framework/files/server/standard_library.go.tmpl
@@ -22,7 +22,7 @@ type Server struct {
 
 func NewServer() *http.Server {
 	port, _ := strconv.Atoi(os.Getenv("PORT"))
-	NewServer := &Server{
+	newServer := &Server{
 		port: port,
   {{if ne .DBDriver "none"}}
 		db:   database.New(),
@@ -31,8 +31,8 @@ func NewServer() *http.Server {
 
 	// Declare Server config
 	server := &http.Server{
-		Addr:         fmt.Sprintf(":%d", NewServer.port),
-		Handler:      NewServer.RegisterRoutes(),
+		Addr:         fmt.Sprintf(":%d", newServer.port),
+		Handler:      newServer.RegisterRoutes(),
 		IdleTimeout:  time.Minute,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,


### PR DESCRIPTION
It fixes #419 


## Problem/Feature
Using 'NewServer' as a variable reference is incorrect. This should be 'newServer' (the local variable) instead of 'NewServer' (which refers to the function name).
