### PR TITLE
fix: exclude .env file from init commit #416

### DIFF
--- a/.github/workflows/test-bug-416.yml
+++ b/.github/workflows/test-bug-416.yml
@@ -1,0 +1,45 @@
+name: Repro Bug 416
+
+on: [push]
+
+jobs:
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23"
+      - name: Install go-blueprint
+        run: go install .
+      - name: Setup git
+        run: |
+          git config --global user.email "test@gmail.com"
+          git config --global user.name "test"
+      - name: Test blueprint
+        run: |
+          go-blueprint create --name test --framework fiber --driver none --git commit
+          cd test
+          echo "All git tracked files:"
+          git ls-files
+          echo "git ignore contents:"
+          cat .gitignore
+          echo "All files in repo:"
+          Get-ChildItem -Force
+        shell: pwsh
+      - name: Check if .env file is committed (should fail if bug exists)
+        run: |
+          cd test
+          $envFileCommitted = git ls-files | Select-String -Pattern "\.env$"
+          if ($envFileCommitted) {
+            echo "ERROR: .env file was committed! Bug 416 is present."
+            echo "Files in commit:"
+            git ls-files
+            exit 1
+          } else {
+            echo "SUCCESS: .env file was not committed."
+            echo "Files in commit:"
+            git ls-files
+          }
+        shell: pwsh

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -656,7 +656,6 @@ func (p *Project) CreateMainFile() error {
 	if err != nil {
 		return err
 	}
-	defer gitignoreFile.Close()
 
 	// inject gitignore template
 	gitignoreTemplate := template.Must(template.New(".gitignore").Parse(string(framework.GitIgnoreTemplate())))
@@ -664,6 +663,8 @@ func (p *Project) CreateMainFile() error {
 	if err != nil {
 		return err
 	}
+
+	gitignoreFile.Close()
 
 	// Create .air.toml file
 	airTomlFile, err := os.Create(filepath.Join(projectPath, ".air.toml"))

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -656,6 +656,7 @@ func (p *Project) CreateMainFile() error {
 	if err != nil {
 		return err
 	}
+	defer gitignoreFile.Close()
 
 	// inject gitignore template
 	gitignoreTemplate := template.Must(template.New(".gitignore").Parse(string(framework.GitIgnoreTemplate())))
@@ -664,7 +665,10 @@ func (p *Project) CreateMainFile() error {
 		return err
 	}
 
-	gitignoreFile.Close()
+	// Ensure file is flushed to storage
+	if err := gitignoreFile.Sync(); err != nil {
+		return err
+	}
 
 	// Create .air.toml file
 	airTomlFile, err := os.Create(filepath.Join(projectPath, ".air.toml"))


### PR DESCRIPTION
Changed gitignore file.close from defer to explicit so as to ensure .gitignore is written before running git commands.

This fixes issue #416.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Please include a description of the problem or feature this PR is addressing.

## Description of Changes: 

- Item 1
- Item 2

## Checklist

- [x] I have self-reviewed the changes being requested
- [x] I have updated the documentation (check issue ticket #218)
