### PR TITLE
refactor: use distinct context variables in graceful shutdown

### DIFF
--- a/cmd/template/framework/files/main/fiber_main.go.tmpl
+++ b/cmd/template/framework/files/main/fiber_main.go.tmpl
@@ -16,20 +16,20 @@ import (
 
 func gracefulShutdown(fiberServer *server.FiberServer, done chan bool) {
 	// Create context that listens for the interrupt signal from the OS.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	// Listen for the interrupt signal.
-	<-ctx.Done()
+	<-sigCtx.Done()
 
 	log.Println("shutting down gracefully, press Ctrl+C again to force")
 	stop() // Allow Ctrl+C to force shutdown
 
 	// The context is used to inform the server it has 5 seconds to finish
 	// the request it is currently handling
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := fiberServer.ShutdownWithContext(ctx); err != nil {
+	if err := fiberServer.ShutdownWithContext(shutdownCtx); err != nil {
 		log.Printf("Server forced to shutdown with error: %v", err)
 	}
 

--- a/cmd/template/framework/files/main/main.go.tmpl
+++ b/cmd/template/framework/files/main/main.go.tmpl
@@ -14,20 +14,20 @@ import (
 
 func gracefulShutdown(apiServer *http.Server, done chan bool) {
 	// Create context that listens for the interrupt signal from the OS.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	sigCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
 	// Listen for the interrupt signal.
-	<-ctx.Done()
+	<-sigCtx.Done()
 
 	log.Println("shutting down gracefully, press Ctrl+C again to force")
 	stop() // Allow Ctrl+C to force shutdown
 
 	// The context is used to inform the server it has 5 seconds to finish
 	// the request it is currently handling
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := apiServer.Shutdown(ctx); err != nil {
+	if err := apiServer.Shutdown(shutdownCtx); err != nil {
 		log.Printf("Server forced to shutdown with error: %v", err)
 	}
 


### PR DESCRIPTION
rename signal context to sigCtx and shutdown context to shutdownCtx for improved readability and to avoid variable shadowing in the gracefulShutdown function.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

Please include a description of the problem or feature this PR is addressing.

## Description of Changes: 

- Item 1
- Item 2

## Checklist

- [x] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
