### PR TITLE
fix: remove pgsql data subfolder on docker-compose volume mount

### DIFF
--- a/cmd/template/docker/files/docker-compose/postgres.tmpl
+++ b/cmd/template/docker/files/docker-compose/postgres.tmpl
@@ -47,7 +47,7 @@ services:
     ports:
       - "${BLUEPRINT_DB_PORT}:5432"
     volumes:
-      - psql_volume_bp:/var/lib/postgresql/data
+      - psql_volume_bp:/var/lib/postgresql
     {{- if .AdvancedOptions.docker }}
     healthcheck:
       test: ["CMD-SHELL", "sh -c 'pg_isready -U ${BLUEPRINT_DB_USERNAME} -d ${BLUEPRINT_DB_DATABASE}'"]


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.

## Problem/Feature

```
psql_bp-1 | Error: in 18+, these Docker images are configured to store database data in a
psql_bp-1 | format which is compatible with "pg_ctlcluster" (specifically, using
psql_bp-1 | major-version-specific directory names). This better reflects how
psql_bp-1 | PostgreSQL itself works, and how upgrades are to be performed.
psql_bp-1 |
psql_bp-1 | See also [https://github.com/docker-library/postgres/pull/1259](vscode-file://vscode-app/c:/Users/cedae/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
psql_bp-1 |
psql_bp-1 | Counter to that, there appears to be PostgreSQL data in:
psql_bp-1 | /var/lib/postgresql/data (unused mount/volume)
psql_bp-1 |
psql_bp-1 | This is usually the result of upgrading the Docker image without
psql_bp-1 | upgrading the underlying database using "pg_upgrade" (which requires both
psql_bp-1 | versions).
psql_bp-1 |
psql_bp-1 | The suggested container configuration for 18+ is to place a single mount
psql_bp-1 | at /var/lib/postgresql which will then place PostgreSQL data in a
psql_bp-1 | subdirectory, allowing usage of "pg_upgrade --link" without mount point
psql_bp-1 | boundary issues.
psql_bp-1 |
psql_bp-1 | See [https://github.com/docker-library/postgres/issues/37](vscode-file://vscode-app/c:/Users/cedae/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for a (long)
psql_bp-1 | discussion around this process, and suggestions for how to do so.
```

## Description of Changes: 

- Removed `data` subfolder from the postgresql volume mount in the docker-compose template.

## Checklist

- [ ] I have self-reviewed the changes being requested
- [ ] I have updated the documentation (check issue ticket #218)
