### PR TITLE
Add Next.js as an advanced feature option and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ You can now use the `--advanced` flag when running the `create` command to get a
 - [Tailwind](https://tailwindcss.com/) css framework
 - Docker configuration for go project
 - [React](https://react.dev/) frontend written in TypeScript, including an example fetch request to the backend
+- [Next.js](https://nextjs.org/) frontend (App Router + TypeScript) with [Tailwind CSS](https://tailwindcss.com/) and [shadcn/ui](https://ui.shadcn.com/) pre-wired, including an example fetch to the Go backend
 
-Note: Selecting Tailwind option will automatically select HTMX unless React is explicitly selected
+Note: Selecting Tailwind option will automatically select HTMX unless React or Next.js is explicitly selected. React, Next.js, and HTMX are mutually exclusive — only one frontend option can be chosen at a time.
 
 <a id="blueprint-ui"></a>
 
@@ -214,10 +215,18 @@ React:
 go-blueprint create --advanced --feature react
 ```
 
-Or all features at once:
+Next.js (App Router, TypeScript, Tailwind, shadcn/ui — all bundled):
 
 ```bash
-go-blueprint create --name my-project --framework chi --driver mysql --advanced --feature htmx --feature githubaction --feature websocket --feature tailwind --feature docker --git commit --feature react
+go-blueprint create --advanced --feature nextjs
+```
+
+The Next.js scaffold runs `create-next-app@latest` with `--ts --app --eslint --src-dir --tailwind --use-npm --import-alias "@/*"`, then initializes shadcn/ui (`init -d`) and adds the `button` and `card` components. A `frontend/.env.local` is created with `NEXT_PUBLIC_API_URL` pointing at the Go backend, and `next.config.mjs` is configured with `output: "standalone"` plus an `/api/*` → Go rewrite so server-side fetches can hit the backend without CORS. When combined with `--feature docker`, the frontend runs as its own compose service on port `3000`.
+
+Or all features at once (picking Next.js as the frontend):
+
+```bash
+go-blueprint create --name my-project --framework chi --driver mysql --advanced --feature nextjs --feature githubaction --feature websocket --feature docker --git commit
 ```
 
 <p align="center">

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -285,6 +285,15 @@ var createCmd = &cobra.Command{
 		fmt.Println(endingMsgStyle.Render("\nNext steps:"))
 		fmt.Println(endingMsgStyle.Render(fmt.Sprintf("• cd into the newly created project with: `cd %s`\n", utils.GetRootDir(project.ProjectName))))
 
+		if options.Advanced.Choices["Nextjs"] {
+			options.Advanced.Choices["React"] = false
+			options.Advanced.Choices["Htmx"] = false
+			options.Advanced.Choices["Tailwind"] = false
+			fmt.Println(endingMsgStyle.Render("• cd into frontend\n"))
+			fmt.Println(endingMsgStyle.Render("• npm install\n"))
+			fmt.Println(endingMsgStyle.Render("• npm run dev\n"))
+		}
+
 		if options.Advanced.Choices["React"] {
 			options.Advanced.Choices["Htmx"] = false
 			options.Advanced.Choices["Tailwind"] = false

--- a/cmd/flags/advancedFeatures.go
+++ b/cmd/flags/advancedFeatures.go
@@ -13,10 +13,11 @@ const (
 	Websocket         string = "websocket"
 	Tailwind          string = "tailwind"
 	React             string = "react"
+	Nextjs            string = "nextjs"
 	Docker            string = "docker"
 )
 
-var AllowedAdvancedFeatures = []string{string(React), string(Htmx), string(GoProjectWorkflow), string(Websocket), string(Tailwind), string(Docker)}
+var AllowedAdvancedFeatures = []string{string(React), string(Nextjs), string(Htmx), string(GoProjectWorkflow), string(Websocket), string(Tailwind), string(Docker)}
 
 func (f AdvancedFeatures) String() string {
 	return strings.Join(f, ",")

--- a/cmd/program/program.go
+++ b/cmd/program/program.go
@@ -407,6 +407,17 @@ func (p *Project) CreateMainFile() error {
 		return err
 	}
 
+	if p.AdvancedOptions[string(flags.Nextjs)] {
+		// deselect htmx/react since nextjs is selected
+		p.AdvancedOptions[string(flags.Htmx)] = false
+		p.AdvancedOptions[string(flags.React)] = false
+		if err := p.CreateNextJSProject(projectPath); err != nil {
+			return fmt.Errorf("failed to set up Next.js project: %w", err)
+		}
+		// tailwind is baked into the Next scaffold; skip downstream tailwind-for-htmx block
+		p.AdvancedOptions[string(flags.Tailwind)] = false
+	}
+
 	if p.AdvancedOptions[string(flags.React)] {
 		// deselect htmx option automatically since react is selected
 		p.AdvancedOptions[string(flags.Htmx)] = false
@@ -927,6 +938,100 @@ func (p *Project) CreateViteReactProject(projectPath string) error {
 
 		// set to false to not re-do in next step
 		p.AdvancedOptions[string(flags.Tailwind)] = false
+	}
+
+	return nil
+}
+
+func (p *Project) CreateNextJSProject(projectPath string) error {
+	if err := checkNpmInstalled(); err != nil {
+		return err
+	}
+
+	originalDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalDir); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to change back to original directory: %v\n", err)
+		}
+	}()
+
+	if err := os.Chdir(projectPath); err != nil {
+		return fmt.Errorf("failed to change into project directory: %w", err)
+	}
+
+	fmt.Println("Scaffolding Next.js app with create-next-app...")
+	cmd := exec.Command("npx", "--yes", "create-next-app@latest", "frontend",
+		"--ts",
+		"--app",
+		"--eslint",
+		"--src-dir",
+		"--tailwind",
+		"--use-npm",
+		"--import-alias", "@/*",
+		"--no-turbopack",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run create-next-app: %w", err)
+	}
+
+	frontendPath := filepath.Join(projectPath, "frontend")
+	if err := os.Chdir(frontendPath); err != nil {
+		return fmt.Errorf("failed to change to frontend directory: %w", err)
+	}
+
+	// Create global .env so we can read the backend PORT.
+	if err := p.CreateFileWithInjection("", projectPath, ".env", "env"); err != nil {
+		return fmt.Errorf("failed to create global .env file: %w", err)
+	}
+
+	backendPort := "8080"
+	if data, readErr := os.ReadFile(filepath.Join(projectPath, ".env")); readErr == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.HasPrefix(line, "PORT=") {
+				backendPort = strings.SplitN(line, "=", 2)[1]
+				break
+			}
+		}
+	}
+
+	frontendEnvContent := fmt.Sprintf("NEXT_PUBLIC_API_URL=http://localhost:%s\n", backendPort)
+	if err := os.WriteFile(filepath.Join(frontendPath, ".env.local"), []byte(frontendEnvContent), 0644); err != nil {
+		return fmt.Errorf("failed to create frontend .env.local: %w", err)
+	}
+
+	// Overwrite next.config with one that proxies /api/* to the Go backend and enables standalone output.
+	nextConfigPath := filepath.Join(frontendPath, "next.config.mjs")
+	if err := os.WriteFile(nextConfigPath, advanced.NextJSConfigFile(), 0644); err != nil {
+		return fmt.Errorf("failed to write next.config.mjs: %w", err)
+	}
+	// create-next-app may emit next.config.ts as well — remove it so .mjs wins.
+	_ = os.Remove(filepath.Join(frontendPath, "next.config.ts"))
+
+	// Initialize shadcn/ui with defaults and add baseline components.
+	fmt.Println("Initializing shadcn/ui...")
+	initCmd := exec.Command("npx", "--yes", "shadcn@latest", "init", "-d", "-y")
+	initCmd.Stdout = os.Stdout
+	initCmd.Stderr = os.Stderr
+	if err := initCmd.Run(); err != nil {
+		return fmt.Errorf("failed to init shadcn/ui: %w", err)
+	}
+
+	addCmd := exec.Command("npx", "--yes", "shadcn@latest", "add", "button", "card", "-y")
+	addCmd.Stdout = os.Stdout
+	addCmd.Stderr = os.Stderr
+	if err := addCmd.Run(); err != nil {
+		return fmt.Errorf("failed to add shadcn components: %w", err)
+	}
+
+	// Overwrite the starter page with one that uses our shadcn Button + Card and fetches from Go.
+	pagePath := filepath.Join(frontendPath, "src", "app", "page.tsx")
+	if err := os.WriteFile(pagePath, advanced.NextJSPageFile(), 0644); err != nil {
+		return fmt.Errorf("failed to write page.tsx template: %w", err)
 	}
 
 	return nil

--- a/cmd/steps/steps.go
+++ b/cmd/steps/steps.go
@@ -99,7 +99,12 @@ func InitSteps(projectType flags.Framework, databaseType flags.Database) *Steps 
 					{
 						Flag:  "React",
 						Title: "React",
-						Desc:  "Use Vite to spin up a React project in TypeScript. This disables selecting HTMX/Templ",
+						Desc:  "Use Vite to spin up a React project in TypeScript. This disables selecting HTMX/Templ and Next.js",
+					},
+					{
+						Flag:  "Nextjs",
+						Title: "Next.js",
+						Desc:  "Scaffold a Next.js app (App Router, TypeScript, Tailwind, shadcn/ui). This disables selecting HTMX/Templ and React",
 					},
 					{
 						Flag:  "Htmx",

--- a/cmd/template/advanced/files/docker/docker_compose.yml.tmpl
+++ b/cmd/template/advanced/files/docker/docker_compose.yml.tmpl
@@ -27,6 +27,20 @@ services:
     depends_on:
       - app
 {{- end }}
+{{- if .AdvancedOptions.nextjs }}
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: frontend
+    restart: unless-stopped
+    ports:
+      - 3000:3000
+    environment:
+      NEXT_PUBLIC_API_URL: http://app:${PORT}
+    depends_on:
+      - app
+{{- end }}
 
 {{- if and (.AdvancedOptions.docker) (eq .DBDriver "sqlite") }}
 volumes:

--- a/cmd/template/advanced/files/docker/dockerfile.tmpl
+++ b/cmd/template/advanced/files/docker/dockerfile.tmpl
@@ -44,3 +44,23 @@ COPY --from=frontend_builder /frontend/dist /app/dist
 EXPOSE 5173
 CMD ["serve", "-s", "/app/dist", "-l", "5173"]
 {{- end}}
+
+{{ if .AdvancedOptions.nextjs}}
+FROM node:20 AS frontend_builder
+WORKDIR /frontend
+
+COPY frontend/package*.json ./
+RUN npm ci
+COPY frontend/. .
+RUN npm run build
+
+FROM node:20-slim AS frontend
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+COPY --from=frontend_builder /frontend/.next/standalone ./
+COPY --from=frontend_builder /frontend/.next/static ./.next/static
+COPY --from=frontend_builder /frontend/public ./public
+EXPOSE 3000
+CMD ["node", "server.js"]
+{{- end}}

--- a/cmd/template/advanced/files/nextjs/next.config.mjs.tmpl
+++ b/cmd/template/advanced/files/nextjs/next.config.mjs.tmpl
@@ -1,0 +1,15 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+  async rewrites() {
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"
+    return [
+      {
+        source: "/api/:path*",
+        destination: `${apiUrl}/:path*`,
+      },
+    ]
+  },
+}
+
+export default nextConfig

--- a/cmd/template/advanced/files/nextjs/page.tsx.tmpl
+++ b/cmd/template/advanced/files/nextjs/page.tsx.tmpl
@@ -1,0 +1,56 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+export default function Home() {
+  const [message, setMessage] = useState<string>("")
+  const [loading, setLoading] = useState<boolean>(false)
+
+  const apiUrl =
+    process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"
+
+  const fetchData = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`${apiUrl}/`)
+      setMessage(await res.text())
+    } catch (err) {
+      console.error("Error fetching data:", err)
+      setMessage("Failed to reach Go backend")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Next.js + Go Blueprint</CardTitle>
+          <CardDescription>
+            Talking to the Go backend at {apiUrl}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Button onClick={fetchData} disabled={loading}>
+            {loading ? "Fetching…" : "Fetch from Go server"}
+          </Button>
+          {message && (
+            <div className="rounded-md bg-muted p-3 text-sm">
+              <p className="font-semibold">Server response:</p>
+              <p className="whitespace-pre-wrap">{message}</p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/cmd/template/advanced/routes.go
+++ b/cmd/template/advanced/routes.go
@@ -22,6 +22,12 @@ var reactTailwindAppFile []byte
 //go:embed files/react/app.tsx.tmpl
 var reactAppFile []byte
 
+//go:embed files/nextjs/page.tsx.tmpl
+var nextjsPageFile []byte
+
+//go:embed files/nextjs/next.config.mjs.tmpl
+var nextjsConfigFile []byte
+
 //go:embed files/tailwind/input.css.tmpl
 var inputCssTemplate []byte
 
@@ -125,6 +131,14 @@ func ReactTailwindAppfile() []byte {
 
 func ReactAppfile() []byte {
 	return reactAppFile
+}
+
+func NextJSPageFile() []byte {
+	return nextjsPageFile
+}
+
+func NextJSConfigFile() []byte {
+	return nextjsConfigFile
 }
 
 func InputCssTemplateReact() []byte {

--- a/cmd/template/framework/files/makefile.tmpl
+++ b/cmd/template/framework/files/makefile.tmpl
@@ -47,15 +47,15 @@ tailwind-install:
 	@if not exist tailwindcss.exe powershell -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri 'https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-windows-x64.exe' -OutFile 'tailwindcss.exe'"{{- end }}
 {{- end }}
 
-build:{{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }} tailwind-install{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }} templ-install{{- end }}
+build:{{- if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) (not .AdvancedOptions.nextjs) }} tailwind-install{{- end }}{{- if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) (not .AdvancedOptions.nextjs) }} templ-install{{- end }}
 	@echo "Building..."
-	{{ if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) }}@templ generate{{- end }}
-	{{ if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) }}@{{ if .OSCheck.UnixBased }}./tailwindcss{{ else }}.\tailwindcss.exe{{ end }} -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css{{ end }}
+	{{ if and (or .AdvancedOptions.htmx .AdvancedOptions.tailwind) (not .AdvancedOptions.react) (not .AdvancedOptions.nextjs) }}@templ generate{{- end }}
+	{{ if and .AdvancedOptions.tailwind (not .AdvancedOptions.react) (not .AdvancedOptions.nextjs) }}@{{ if .OSCheck.UnixBased }}./tailwindcss{{ else }}.\tailwindcss.exe{{ end }} -i cmd/web/styles/input.css -o cmd/web/assets/css/output.css{{ end }}
 	{{ if .OSCheck.UnixBased }}@{{- if and (.AdvancedOptions.docker) (eq .DBDriver "sqlite") }}CGO_ENABLED=1 GOOS=linux {{ end }}go build -o main cmd/api/main.go{{- else }}@go build -o main.exe cmd/api/main.go{{- end }}
 
 # Run the application
 run:
-	@go run cmd/api/main.go{{- if .AdvancedOptions.react }} &
+	@go run cmd/api/main.go{{- if or .AdvancedOptions.react .AdvancedOptions.nextjs }} &
 	@npm install --prefer-offline --no-fund --prefix ./frontend
 	@npm run dev --prefix ./frontend
 	{{- end }}

--- a/docs/docs/advanced-flag/nextjs.md
+++ b/docs/docs/advanced-flag/nextjs.md
@@ -1,0 +1,96 @@
+The Next.js advanced flag scaffolds a modern Next.js frontend alongside your Go backend. It runs the official `create-next-app` CLI with sensible defaults and initializes [shadcn/ui](https://ui.shadcn.com/) so you have production-grade components available from the first commit.
+
+The Next.js flag is mutually exclusive with the React and HTMX/Templ flags — only one frontend option may be selected at a time.
+
+## What it generates
+
+`create-next-app@latest` is invoked with:
+
+```
+--ts --app --eslint --src-dir --tailwind --use-npm --import-alias "@/*"
+```
+
+Which gives you:
+
+- **App Router** (Next.js 13+ default)
+- **TypeScript**
+- **Tailwind CSS** (baked in — no separate `--feature tailwind` needed)
+- **ESLint**
+- **`src/` directory** layout
+- **`@/*` import alias**
+
+On top of that, the blueprint:
+
+- Runs `npx shadcn@latest init -d` and adds the `button` and `card` components as a baseline.
+- Overwrites `src/app/page.tsx` with a starter page that fetches from the Go backend using `process.env.NEXT_PUBLIC_API_URL`.
+- Writes `frontend/.env.local` with `NEXT_PUBLIC_API_URL=http://localhost:<PORT>` (read from the project's root `.env`).
+- Writes `frontend/next.config.mjs` with `output: "standalone"` and a `rewrites()` rule proxying `/api/:path*` to the Go backend — useful for server-side fetches where `NEXT_PUBLIC_*` is not appropriate.
+
+## Project structure
+
+```bash
+/ (Root)
+├── frontend/                     # Next.js advanced flag. Excludes HTMX and React.
+│   ├── .env.local                # NEXT_PUBLIC_API_URL pointing at the Go backend.
+│   ├── next.config.mjs           # standalone output + /api/* proxy to Go.
+│   ├── components.json           # shadcn/ui config.
+│   ├── src/
+│   │   ├── app/
+│   │   │   ├── layout.tsx
+│   │   │   └── page.tsx          # Overwritten with a Go-backend demo page.
+│   │   ├── components/ui/        # shadcn components (button, card, ...).
+│   │   └── lib/utils.ts
+│   ├── public/
+│   ├── tsconfig.json
+│   └── package.json
+```
+
+## Usage
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The Next.js dev server runs on `http://localhost:3000` and talks to the Go backend on `http://localhost:8080` (or whatever `PORT` is set to).
+
+## Makefile
+
+`make run` starts the Go server and the Next.js dev server together:
+
+```makefile
+run:
+    @go run cmd/api/main.go &
+    @npm install --prefer-offline --no-fund --prefix ./frontend
+    @npm run dev --prefix ./frontend
+```
+
+## Docker
+
+Combine with the `docker` feature to get a multi-stage Dockerfile and docker-compose service. The frontend service is exposed on `3000` and points at the `app` service via `NEXT_PUBLIC_API_URL=http://app:${PORT}`. Spin everything up with:
+
+```bash
+make docker-run
+```
+
+## Environment variables
+
+| Variable | Where | Purpose |
+|---|---|---|
+| `PORT` | project `.env` | Go backend port |
+| `NEXT_PUBLIC_API_URL` | `frontend/.env.local` | Base URL the client uses to call the Go API |
+
+If you change `PORT`, update `NEXT_PUBLIC_API_URL` to match.
+
+## Adding more shadcn components
+
+```bash
+cd frontend
+npx shadcn@latest add dialog input form
+```
+
+## Notes
+
+- The first run downloads `create-next-app` and shadcn dependencies; subsequent runs are much faster thanks to npm's cache.
+- `--no-turbopack` is passed for stability; swap it out once Turbopack graduates.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - Websocket: advanced-flag/websocket.md
     - Docker: advanced-flag/docker.md
     - React & Vite (TypeScript): advanced-flag/react-vite.md
+    - Next.js (App Router + shadcn/ui): advanced-flag/nextjs.md
   - Testing endpoints: 
     - Server: endpoints-test/server.md
     - DB Health Endpoints: 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.                                                                       
                                                                                                                                                                                    
  ## Problem/Feature
                                                                                                                                                                                    
  Add **Next.js** as a first-class frontend option in the advanced-features set, alongside the existing React (Vite) and HTMX/Templ choices. Users who want a modern full-stack     
  setup with App Router, TypeScript, Tailwind, and shadcn/ui can now scaffold everything with a single flag, wired up to the Go backend out of the box.
                                                                                                                                                                                    
  ## Description of Changes                              

  - **New `--feature nextjs` flag** — added `Nextjs` constant in `cmd/flags/advancedFeatures.go` and appended it to `AllowedAdvancedFeatures`. Shows up automatically in            
  `go-blueprint create --help`.
  - **TUI checkbox** — new "Next.js" item in the advanced-features multi-select (`cmd/steps/steps.go`).                                                                             
  - **Mutual exclusion** — Next.js ⟂ React ⟂ HTMX. Selecting Next.js clears React/HTMX/Tailwind flags in both `cmd/create.go` and `cmd/program/program.go`.                         
  - **`CreateNextJSProject()`** in `cmd/program/program.go` that:                                                                                                                   
    - Runs `npx create-next-app@latest frontend --ts --app --eslint --src-dir --tailwind --use-npm --import-alias "@/*" --no-turbopack`                                             
    - Initializes shadcn/ui non-interactively (`npx shadcn@latest init -d`) and adds `button` + `card` as baseline components                                                       
    - Writes `frontend/.env.local` with `NEXT_PUBLIC_API_URL=http://localhost:<PORT>` (read from the project's root `.env`, same pattern used for React's `VITE_PORT`)              
    - Writes `frontend/next.config.mjs` with `output: "standalone"` and an `/api/*` → Go backend `rewrites()` rule so server-side fetches work without CORS                         
    - Overwrites `src/app/page.tsx` with a demo page using shadcn `<Button>` + `<Card>` that fetches from the Go backend                                                            
  - **Embedded templates** — new files under `cmd/template/advanced/files/nextjs/` (`page.tsx.tmpl`, `next.config.mjs.tmpl`) and matching `//go:embed` + accessors in               
  `cmd/template/advanced/routes.go`.                                                                                                                                                
  - **Docker integration** — added `{{ if .AdvancedOptions.nextjs }}` blocks in `Dockerfile.tmpl` (multi-stage build using Next's standalone output, runs on `:3000`) and
  `docker_compose.yml.tmpl` (frontend service with `NEXT_PUBLIC_API_URL` pointing at the `app` service).                                                                            
  - **Makefile** — extended `run` target's conditional so `make run` boots both the Go server and the Next.js dev server. Templ/Tailwind build steps are correctly skipped when
  `nextjs` is selected.                                                                                                                                                             
  - **Docs** — new `docs/docs/advanced-flag/nextjs.md` and nav entry in `docs/mkdocs.yml`. README's Advanced Features list and usage examples updated.
                                                                                                                                                                                    
  ### CLI example                                        
                                                                                                                                                                                    
  ```bash                                                
  go-blueprint create \
    --name myapp \
    --framework chi \
    --driver postgres \                                                                                                                                                             
    --advanced \
    --feature nextjs \                                                                                                                                                              
    --feature docker \                                   
    --git commit
  ```

  ## Checklist

  - [x] I have self-reviewed the changes being requested                                                                                                                            
  - [x] I have updated the documentation (check issue ticket #218)